### PR TITLE
refactor: change ijemmao to nkowaokwu org

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Contributions are always welcome. Before contributing please read the [Code of C
 
 ## Feature Requests
 
-Feature requests should be captured through the repo's [issues](https://github.com/ijemmao/igbo_api/issues), with a description of the expected behavior, along with a use case. Please use a label that describes the nature of the issue. If you would like to work on said issue, leave a comment on it so that you can be assigned to it by the repo owner.
+Feature requests should be captured through the repo's [issues](https://github.com/nkowaokwu/igbo_api/issues), with a description of the expected behavior, along with a use case. Please use a label that describes the nature of the issue. If you would like to work on said issue, leave a comment on it so that you can be assigned to it by the repo owner.
 
 
-Before opening an issue, please read through the [issues](https://github.com/ijemmao/igbo_api/issues); your issue may have already ben discussed or fixed in `master` or `gatsby-dev`.
+Before opening an issue, please read through the [issues](https://github.com/nkowaokwu/igbo_api/issues); your issue may have already ben discussed or fixed in `master` or `gatsby-dev`.
 
 ## Areas of Contribution
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Igbo API
-![backup_production](https://github.com/ijemmao/igbo_api/workflows/backup_production/badge.svg?event=schedule)
+![backup_production](https://github.com/nkowaokwu/igbo_api/workflows/backup_production/badge.svg?event=schedule)
 
-[Contributing](./.github/CONTRIBUTING.md) | [Documentation](https://github.com/ijemmao/igbo_api/wiki) | [Code of Conduct](./.github/CODE_OF_CONDUCT.md) | [Slack Channel](https://igboapi.slack.com)
+[Contributing](./.github/CONTRIBUTING.md) | [Documentation](https://github.com/nkowaokwu/igbo_api/wiki) | [Code of Conduct](./.github/CODE_OF_CONDUCT.md) | [Slack Channel](https://igboapi.slack.com)
 
 > Igbo is the principal native language of the Igbo people, an ethnic group of southeastern Nigeria, and is spoken by approx 45 million people in at least 20 different dialects.
 
@@ -27,7 +27,7 @@ To run this project locally, the following tools need to be installed:
 Clone the project:
 
 ```
-git clone https://github.com/ijemmao/igbo_api.git
+git clone https://github.com/nkowaokwu/igbo_api.git
 ```
 
 Move into the project directory and install it's dependencies:

--- a/src/middleware/analytics.js
+++ b/src/middleware/analytics.js
@@ -29,12 +29,16 @@ const trackEvent = ({
     }],
   });
 
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV !== 'production') {
     axios({
       method: 'post',
       url: `${GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
       data,
     })
+      .then((res) => {
+        console.log('Logging the data:', JSON.parse(data), JSON.parse(data).events[0].params);
+        console.log({ status: res.status, response: res.data });
+      })
       .catch((err) => console.log(typeof err?.toJSON === 'function' ? err.toJSON() : err));
   } else {
     axios({

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -68,7 +68,7 @@ const About = () => {
           {language === 'en' ? (
             <p>
               {'This is an '}
-              <a className="link" href="https://github.com/ijemmao/igbo_api">
+              <a className="link" href="https://github.com/nkowaokwu/igbo_api">
                 open-source project
               </a>
               {' created by '}

--- a/src/pages/components/Footer/Footer.js
+++ b/src/pages/components/Footer/Footer.js
@@ -35,7 +35,7 @@ const Footer = () => {
                 text-center bg-white rounded-full w-12 h-12 m-2 hover:bg-gray-200
                 transition-all duration-200"
               >
-                <a href="https://github.com/ijemmao/igbo_api">
+                <a href="https://github.com/nkowaokwu/igbo_api">
                   <i className="fa fa-github text-4xl p-1" />
                 </a>
               </div>

--- a/src/public/locales/ig/about.json
+++ b/src/public/locales/ig/about.json
@@ -4,7 +4,7 @@
   "Our main goal is to make an easy-to-access, robust, lexical Igbo language resource to help solve a variety of complex problems within the worlds of education to Machine Learning.": "Ebumnobi ka anyị mkpa bụ imepụta ebenchọpụta asụsụ Igbo dị mfe iru aka, jupụta ejupụta, ma bụrụ mkpụrụasụsụ Igbo.",
   "The Igbo API hosts and serves all word and example sentence data that is shown on Nkọwa okwu, our official online Igbo-English dictionary app.": "API Igbo bụ ebe mkpụrụokwu niile na data omụmaatụ ahịrịokwu e gosipụtara na <a class=\"link\" href=\"https://nkowaokwu.com\">Nkọwa okwu</a> dị. ọkọwookwu ịntaneetị izugbe anyị.",
   "The initial words and examples that populated this API came from Kay Williamson's Igbo Dictionary entitled Dictionary of Ònìchà Igbo.": "Mkpụrụokwu na ọmụmaatụ mbụ jupụtara na API a si na ọkọwookwu Igbo Kay Williamson nke ọ kpọrọ  <a class=\"link\" href=\"http://www.columbia.edu/itc/mealac/pritchett/00fwp/igbo/IGBO%20Dictionary.pdf\">“Dictionary of Ònìchà Igbo”</a>.",
-  "This is an open-source project created by Ijemma Onwuzulike.": "Ihe a bụ <a class=\"link\" href=\"https://github.com/ijemmao/igbo_api\">ọrụ isi ndebanye ya ghe oghe</a> nke <a class=\"link\" href=\"https://twitter.com/ijemmaohno\">Ijemma Onwuzulike</a> mepụtara.",
+  "This is an open-source project created by Ijemma Onwuzulike.": "Ihe a bụ <a class=\"link\" href=\"https://github.com/nkowaokwu/igbo_api\">ọrụ isi ndebanye ya ghe oghe</a> nke <a class=\"link\" href=\"https://twitter.com/ijemmaohno\">Ijemma Onwuzulike</a> mepụtara.",
   "Contact": "Mkpọtụrụ",
   "Email": "Iimeelụ"
 }

--- a/src/siteConstants.js
+++ b/src/siteConstants.js
@@ -5,6 +5,6 @@ export const API_ROUTE = process.env.DOMAIN_NAME
   : `http://localhost:${PORT}`;
 export const API_FROM_EMAIL = process.env.API_FROM_EMAIL || 'kedu@nkowaokwu.com';
 export const DICTIONARY_APP_URL = 'https://nkowaokwu.com/home';
-export const GITHUB_REPO = 'https://github.com/ijemmao/igbo_api';
-export const GITHUB_CONTRIBUTORS = 'https://api.github.com/repos/ijemmao/igbo_api/contributors';
-export const GITHUB_STARS = 'https://api.github.com/repos/ijemmao/igbo_api';
+export const GITHUB_REPO = 'https://github.com/nkowaokwu/igbo_api';
+export const GITHUB_CONTRIBUTORS = 'https://api.github.com/repos/nkowaokwu/igbo_api/contributors';
+export const GITHUB_STARS = 'https://api.github.com/repos/nkowaokwu/igbo_api';


### PR DESCRIPTION
## Background
Now that the Igbo API lives under the `nkowaokwu` organization, all links will need to be updated that originally pointed to the `ijemmao` account.