### PR TITLE
Support word `attributes` field

### DIFF
--- a/migrations/20220423222134-add-attributes.js
+++ b/migrations/20220423222134-add-attributes.js
@@ -1,0 +1,41 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $set: {
+            attributes: {
+              isStandardIgbo: '$isStandardIgbo',
+              isAccented: '$isAccented',
+              isComplete: '$isComplete',
+              isSlang: false,
+              isConstructedTerm: false,
+            },
+          },
+        },
+        {
+          $unset: ['isStandardIgbo', 'isAccented', 'isComplete'],
+        },
+      ]);
+    });
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $set: {
+            isStandardIgbo: '$attributes.isStandardIgbo',
+            isAccented: '$attributes.isAccented',
+            isComplete: '$attributes.isComplete',
+          },
+        },
+        {
+          $unset: ['attributes'],
+        },
+      ]);
+    });
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -3,6 +3,7 @@
 
 import { assign, map, forEach } from 'lodash';
 import Word from '../../models/Word';
+import WordAttributes from '../../shared/constants/WordAttributes';
 
 /**
  * Removes _id and __v from nested documents
@@ -74,8 +75,7 @@ export const findWordsWithMatch = async ({
       stems: 1,
       updatedAt: 1,
       pronunciation: 1,
-      isAccented: 1,
-      isStandardIgbo: 1,
+      attributes: 1,
       synonyms: 1,
       antonyms: 1,
       hypernyms: 1,
@@ -84,6 +84,10 @@ export const findWordsWithMatch = async ({
       ...(examples ? { examples: 1 } : {}),
       ...(dialects ? { dialects: 1 } : {}),
     })
+    .append([
+      { $unset: `attributes.${WordAttributes.IS_COMPLETE.value}` },
+      { $unset: `attributes.${WordAttributes.IS_CONSTRUCTED_TERM.value}` },
+    ])
     .skip(skip)
     .limit(limit);
 

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -25,7 +25,7 @@ export const searchForAllWordsWithAudioPronunciations = () => ({
   $expr: { $gt: [{ $strLenCP: '$pronunciation' }, 10] },
 });
 export const searchForAllWordsWithIsStandardIgbo = () => ({
-  isStandardIgbo: true,
+  attributes: { isStandardIgbo: true },
 });
 export const searchForAllWordsWithNsibidi = () => ({
   nsibidi: { $ne: '' },

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -1,13 +1,13 @@
 import createRegExp from '../../shared/utils/createRegExp';
 
-const fullTextSearchQuery = ({ keyword, isUsingMainKey, requiredAttributes }) => (isUsingMainKey && !keyword
-  ? { word: { $regex: /./ }, ...requiredAttributes }
-  : { $text: { $search: keyword }, ...requiredAttributes }
+const fullTextSearchQuery = ({ keyword, isUsingMainKey, filteringParams }) => (isUsingMainKey && !keyword
+  ? { word: { $regex: /./ }, ...filteringParams }
+  : { $text: { $search: keyword }, ...filteringParams }
 );
 
-const definitionsQuery = ({ regex, requiredAttributes }) => ({
+const definitionsQuery = ({ regex, filteringParams }) => ({
   definitions: { $in: [regex] },
-  ...requiredAttributes,
+  ...filteringParams,
 });
 
 /* Regex match query used to later to defined the Content-Range response header */
@@ -25,7 +25,7 @@ export const searchForAllWordsWithAudioPronunciations = () => ({
   $expr: { $gt: [{ $strLenCP: '$pronunciation' }, 10] },
 });
 export const searchForAllWordsWithIsStandardIgbo = () => ({
-  attributes: { isStandardIgbo: true },
+  'attributes.isStandardIgbo': true,
 });
 export const searchForAllWordsWithNsibidi = () => ({
   nsibidi: { $ne: '' },

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -40,27 +40,30 @@ export const searchWordUsingEnglish = async ({ query, searchWord, ...rest }) => 
 
 /* Creates an object containing truthy key/value pairs for looking up words */
 const generateRequiredWordAttributes = (requiredAttributes) => (
-  Object.entries(requiredAttributes).reduce((attributes, [key, value]) => {
+  Object.entries(requiredAttributes).reduce((finalRequiredAttributes, [key, value]) => {
     if (key === 'isStandardIgbo' && value) {
       return {
-        ...attributes,
-        [key]: { $eq: true },
+        ...finalRequiredAttributes,
+        attributes: {
+          ...(finalRequiredAttributes.attributes || {}),
+          [key]: { $eq: true },
+        },
       };
     }
     if (key === 'nsibidi' && value) {
       return {
-        ...attributes,
+        ...finalRequiredAttributes,
         [key]: { $ne: '' },
       };
     }
     if (key === 'pronunciation' && value) {
       return {
-        ...attributes,
+        ...finalRequiredAttributes,
         pronunciation: { $exists: true },
         $expr: { $gt: [{ $strLenCP: '$pronunciation' }, 10] },
       };
     }
-    return attributes;
+    return finalRequiredAttributes;
   }, {})
 );
 

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -4,6 +4,7 @@ import { toJSONPlugin, toObjectPlugin } from './plugins';
 import Dialects from '../shared/constants/Dialects';
 import Tenses from '../shared/constants/Tenses';
 import WordClass from '../shared/constants/WordClass';
+import WordAttributes from '../shared/constants/WordAttributes';
 
 const REQUIRED_DIALECT_KEYS = ['variations', 'dialects', 'pronunciation'];
 const REQUIRED_DIALECT_CONSTANT_KEYS = ['code', 'value', 'label'];
@@ -46,9 +47,12 @@ const wordSchema = new Schema({
     required: false,
     default: {},
   },
+  attributes: Object.entries(WordAttributes)
+    .reduce((finalAttributes, [, { value }]) => ({
+      ...finalAttributes,
+      [value]: { type: Boolean, default: false },
+    }), {}),
   pronunciation: { type: String, default: '' },
-  isAccented: { type: Boolean, default: false },
-  isStandardIgbo: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },
   synonyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
@@ -57,7 +61,6 @@ const wordSchema = new Schema({
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   stems: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '' },
-  isComplete: { type: Boolean, default: false },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 const tensesIndexes = Object.values(Tenses).reduce((finalIndexes, tense) => ({

--- a/src/shared/constants/WordAttributes.js
+++ b/src/shared/constants/WordAttributes.js
@@ -1,0 +1,22 @@
+export default {
+  IS_STANDARD_IGBO: {
+    value: 'isStandardIgbo',
+    label: 'Is Standard Igbo',
+  },
+  IS_ACCENTED: {
+    value: 'isAccented',
+    label: 'Is Accented',
+  },
+  IS_COMPLETE: {
+    value: 'isComplete',
+    label: 'Is Complete',
+  },
+  IS_SLANG: {
+    value: 'isSlang',
+    label: 'Is Slang',
+  },
+  IS_CONSTRUCTED_TERM: {
+    value: 'isConstructedTerm',
+    label: 'Is Constructed Term',
+  },
+};

--- a/swagger.json
+++ b/swagger.json
@@ -39,8 +39,22 @@
         "pronunciation": {
           "type": "string"
         },
-        "isStandardIgbo": {
-          "type": "string"
+        "attributes": {
+          "type": "object",
+          "properties": {
+            "isStandardIgbo": {
+              "type": "boolean"
+            },
+            "isAccented": {
+              "type": "boolean"
+            },
+            "isSlang": {
+              "type": "boolean"
+            },
+            "isConstructedTerm": {
+              "type": "boolean"
+            }
+          }
         },
         "variations": {
           "type": "array",

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -594,7 +594,9 @@ describe('MongoDB Words', () => {
         definitions: ['first definition', 'second definition'],
         dialects: {},
         examples: [new ObjectId(), new ObjectId()],
-        isStandardIgbo: true,
+        attributes: {
+          isStandardIgbo: true,
+        },
         stems: [],
       };
       const validWord = new Word(word);
@@ -604,7 +606,7 @@ describe('MongoDB Words', () => {
             expect(res.status).to.equal(200);
             expect(res.body).to.have.lengthOf.at.least(1);
             forEach(res.body, (wordRes) => {
-              expect(wordRes.isStandardIgbo).to.be.equal(true);
+              expect(wordRes.attributes.isStandardIgbo).to.be.equal(true);
             });
             getWords({ keyword: word.word, pronunciation: true })
               .end((error, noRes) => {

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -20,8 +20,7 @@ export const WORD_KEYS = [
   'hypernyms',
   'hyponyms',
   'nsibidi',
-  'isAccented',
-  'isStandardIgbo',
+  'attributes',
   'updatedAt',
 ];
 export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'pronunciation', 'updatedAt', 'createdAt'];


### PR DESCRIPTION
## Background
The word model will now support the new field `attributes` which will replace the top-level `isComplete`, `isAccented`, and `isStandardIgbo` fields. These fields will now live inside the new `attributes` field.

This PR also introduces the new nested `attribute` fields `isSlang` for words that are considered to be slang and `isConstructedTerm` for newly formed Igbo words.