### PR TITLE
Expand Example Sentences

### DIFF
--- a/migrations/20220425130741-extend-example-sentences-with-style-and-meaning.js
+++ b/migrations/20220425130741-extend-example-sentences-with-style-and-meaning.js
@@ -1,0 +1,26 @@
+module.exports = {
+  async up(db) {
+    const collections = ['examples', 'examplesuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $set: {
+            meaning: '',
+            style: '',
+          },
+        },
+      ]);
+    });
+  },
+
+  async down(db) {
+    const collections = ['examples', 'examplesuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $unset: ['meaning', 'style'],
+        },
+      ]);
+    });
+  },
+};

--- a/src/models/Example.js
+++ b/src/models/Example.js
@@ -1,10 +1,17 @@
 import mongoose from 'mongoose';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
+import ExampleStyles from '../shared/constants/ExampleStyles';
 
 const { Schema, Types } = mongoose;
 const exampleSchema = new Schema({
   igbo: { type: String, default: '' },
   english: { type: String, default: '' },
+  meaning: { type: String, default: '' },
+  style: {
+    type: String,
+    enum: Object.values(ExampleStyles).map(({ value }) => value),
+    default: ExampleStyles.NO_STYLE.value,
+  },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   pronunciation: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });

--- a/src/shared/constants/ExampleStyles.js
+++ b/src/shared/constants/ExampleStyles.js
@@ -1,0 +1,14 @@
+export default {
+  NO_STYLE: {
+    value: '',
+    label: 'No Style',
+  },
+  STANDARD: {
+    value: 'standard',
+    label: 'Standard',
+  },
+  PROVERB: {
+    value: 'proverb',
+    label: 'Proverb',
+  },
+};

--- a/tests/shared/constants.js
+++ b/tests/shared/constants.js
@@ -23,7 +23,17 @@ export const WORD_KEYS = [
   'attributes',
   'updatedAt',
 ];
-export const EXAMPLE_KEYS = ['igbo', 'english', 'associatedWords', 'id', 'pronunciation', 'updatedAt', 'createdAt'];
+export const EXAMPLE_KEYS = [
+  'igbo',
+  'english',
+  'meaning',
+  'style',
+  'associatedWords',
+  'id',
+  'pronunciation',
+  'updatedAt',
+  'createdAt',
+];
 export const EXCLUDE_KEYS = ['__v', '_id'];
 export const SITE_TITLE = 'The First African Language API';
 export const DOCS_SITE_TITLE = 'Igbo API Documentation';


### PR DESCRIPTION
## Background
This PR introduces two new fields to the Example model: `meaning` and `style`.

* `meaning` is a secondary field for English translation. This field should be used to describe the meaning of a sentence if the literal translation, which would live in the `english` field, isn't clear enough
* `style` is a field to start labeling sentences.