### PR TITLE
chore: include db directory but exclude contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ yarn-error.log*
 lerna-debug.log*
 
 # MongoDB Database
-db/
 dump/
 mongos/
 

--- a/db/.gitignore
+++ b/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Background
The `db` directory is now included in the project to allow Windows users to avoid the `NonExistentPath` error that gets thrown by MongoDB when it can't find the `db` directory out-of-the-box.