### PR TITLE
feat(homepage): show developers count stat on the homepage

### DIFF
--- a/src/controllers/stats.js
+++ b/src/controllers/stats.js
@@ -1,9 +1,11 @@
 import Word from '../models/Word';
 import Example from '../models/Example';
+import Developer from '../models/Developer';
 import {
   searchForAllWordsWithAudioPronunciations,
   searchForAllWordsWithIsStandardIgbo,
   searchForAllWordsWithNsibidi,
+  searchForAllDevelopers,
 } from './utils/queries';
 
 export const getStats = async (_, res, next) => {
@@ -13,12 +15,14 @@ export const getStats = async (_, res, next) => {
     const totalAudioPronunciations = await Word.find(searchForAllWordsWithAudioPronunciations());
     const totalStandardIgboWords = await Word.find(searchForAllWordsWithIsStandardIgbo());
     const totalNsibidiWords = await Word.find(searchForAllWordsWithNsibidi());
+    const totalDevelopers = await Developer.find(searchForAllDevelopers());
     return res.send({
       totalWords,
       totalExamples,
       totalAudioPronunciations: totalAudioPronunciations.length,
       totalStandardIgboWords: totalStandardIgboWords.length,
       totalNsibidiWords: totalNsibidiWords.length,
+      totalDevelopers: totalDevelopers.length,
     });
   } catch (err) {
     return next(err);

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -30,3 +30,7 @@ export const searchForAllWordsWithIsStandardIgbo = () => ({
 export const searchForAllWordsWithNsibidi = () => ({
   nsibidi: { $ne: '' },
 });
+
+export const searchForAllDevelopers = () => ({
+  name: { $ne: '' },
+});

--- a/src/pages/components/Statistics/Statistics.js
+++ b/src/pages/components/Statistics/Statistics.js
@@ -10,6 +10,7 @@ const Statistics = ({
   totalAudioPronunciations,
   totalStandardIgboWords,
   totalNsibidiWords,
+  totalDevelopers,
   contributors,
   stars,
 }) => {
@@ -29,6 +30,7 @@ const Statistics = ({
           header={t('Standard Igbo words').replace('{{number}}', totalStandardIgboWords)}
         />
         <Stat value={totalNsibidiWords} header={t('Words in Nsịbịdị').replace('{{number}}', totalNsibidiWords)} />
+        <Stat value={totalDevelopers} header={t('Developers using the Igbo API')} />
       </div>
       <div className="flex flex-row justify-center items-center flex-wrap w-full lg:w-9/12">
         {contributors ? (
@@ -72,6 +74,7 @@ Statistics.propTypes = {
   totalAudioPronunciations: PropTypes.number,
   totalStandardIgboWords: PropTypes.number,
   totalNsibidiWords: PropTypes.number,
+  totalDevelopers: PropTypes.number,
   contributors: PropTypes.arrayOf(PropTypes.shape({})),
   stars: PropTypes.number,
 };
@@ -82,6 +85,7 @@ Statistics.defaultProps = {
   totalAudioPronunciations: 0,
   totalStandardIgboWords: 0,
   totalNsibidiWords: 0,
+  totalDevelopers: 0,
   contributors: [],
   stars: 0,
 };

--- a/src/public/locales/en/common.json
+++ b/src/public/locales/en/common.json
@@ -38,6 +38,7 @@
   "Members in Slack": "Members in Slack",
   "GitHub stars": "GitHub stars",
   "Words in Nsịbịdị": "Words in Nsịbịdị",
+  "Developers using the Igbo API": "Developers using the Igbo API",
   "Interested in what you see? Register for an API Key!": "Interested in what you see? Register for an API Key!",
   "Copyright": "Copyright"
 }

--- a/src/public/locales/ig/common.json
+++ b/src/public/locales/ig/common.json
@@ -38,6 +38,7 @@
   "Members in Slack": "Ndị otu {{number}}+ na Slack",
   "GitHub stars": "Mmadụ {{number}} a ma ama na GitHub",
   "Words in Nsịbịdị": "Mkpụrụokwu {{number}} e dere na Nsịbịdị",
+  "Developers using the Igbo API": "Ndị nrụpụta na-eji Igbo API",
   "Interested in what you see? Register for an API Key!": "Uche gị, ọ dị n’ihe ị na-ahụ? Deba aha gị ka e nye gị akara API!",
   "Copyright": "Iwunnwere"
 }


### PR DESCRIPTION
## Background
The Igbo API homepage will now show the total number of developers that have registered for an Igbo API token

## Stat on Homepage
<img width="590" alt="Screen Shot 2022-07-25 at 2 48 13 PM" src="https://user-images.githubusercontent.com/16169291/180851758-44520b87-354a-4833-a5b2-174784ebb16e.png">
.