### PR TITLE
feat: add the `isBorrowedTerm` attribute for words

### DIFF
--- a/migrations/20220808024209-add-borrowed-term-field.js
+++ b/migrations/20220808024209-add-borrowed-term-field.js
@@ -1,0 +1,32 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $set: {
+            attributes: {
+              isStandardIgbo: '$attributes.isStandardIgbo',
+              isAccented: '$attributes.isAccented',
+              isComplete: '$attributes.isComplete',
+              isSlang: '$attributes.isSlang',
+              isConstructedTerm: '$attributes.isConstructedTerm',
+              isBorrowedTerm: false,
+            },
+          },
+        },
+      ]);
+    });
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $unset: 'attributes.isBorrowedTerm',
+        },
+      ]);
+    });
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -86,6 +86,7 @@ export const findWordsWithMatch = async ({
     })
     .append([
       { $unset: `attributes.${WordAttributes.IS_COMPLETE.value}` },
+      { $unset: `attributes.${WordAttributes.IS_BORROWED_TERM.value}` },
       { $unset: `attributes.${WordAttributes.IS_CONSTRUCTED_TERM.value}` },
     ])
     .skip(skip)

--- a/src/shared/constants/WordAttributes.js
+++ b/src/shared/constants/WordAttributes.js
@@ -19,4 +19,8 @@ export default {
     value: 'isConstructedTerm',
     label: 'Is Constructed Term',
   },
+  IS_BORROWED_TERM: {
+    value: 'isBorrowedTerm',
+    label: 'Is Borrowed Term',
+  },
 };

--- a/swagger.json
+++ b/swagger.json
@@ -53,6 +53,9 @@
             },
             "isConstructedTerm": {
               "type": "boolean"
+            },
+            "isBorrowedTerm": {
+              "type": "boolean"
             }
           }
         },


### PR DESCRIPTION
## Background
To provide more nuance to words, word documents will now have the new `isBorrowedTerm` attribute. This PR performs a MongoDB migration to add the new field.