### PR TITLE
feat: add tags for words

### DIFF
--- a/migrations/20220808033804-add-tags.js
+++ b/migrations/20220808033804-add-tags.js
@@ -1,0 +1,25 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions', 'genericwords'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $set: {
+            tags: [],
+          },
+        },
+      ]);
+    });
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions', 'genericwords'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, [
+        {
+          $unset: ['tags'],
+        },
+      ]);
+    });
+  },
+};

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -5,6 +5,7 @@ import Dialects from '../shared/constants/Dialects';
 import Tenses from '../shared/constants/Tenses';
 import WordClass from '../shared/constants/WordClass';
 import WordAttributes from '../shared/constants/WordAttributes';
+import WordTags from '../shared/constants/WordTags';
 
 const REQUIRED_DIALECT_KEYS = ['variations', 'dialects', 'pronunciation'];
 const REQUIRED_DIALECT_CONSTANT_KEYS = ['code', 'value', 'label'];
@@ -35,6 +36,13 @@ const wordSchema = new Schema({
     },
     required: false,
     default: {},
+  },
+  tags: {
+    type: [String],
+    default: [],
+    validate: (v) => (
+      v.every((tag) => Object.values(WordTags).map(({ value }) => value).includes(tag))
+    ),
   },
   tenses: {
     type: Object,

--- a/src/shared/constants/WordTags.js
+++ b/src/shared/constants/WordTags.js
@@ -1,0 +1,26 @@
+export default {
+  MEDICINE: {
+    value: 'medicine',
+    label: 'Medicine',
+  },
+  TECHNOLOGY: {
+    value: 'technology',
+    label: 'Technology',
+  },
+  EDUCATION: {
+    value: 'education',
+    label: 'Education',
+  },
+  ARTS: {
+    value: 'arts',
+    label: 'Arts',
+  },
+  TRANSPORTAION: {
+    value: 'transportaion',
+    label: 'Transportaion',
+  },
+  CULTURE: {
+    value: 'culture',
+    label: 'Culture',
+  },
+};


### PR DESCRIPTION
## Background
To encourage better filtering and searching for users, there will be a new `tags` field that will live on each word document. This PR migrates the MongoDB.