### PR TITLE
fix(search): normalize string using NFD and create custom query for individual fields

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -61,9 +61,10 @@ export const findWordsWithMatch = async ({
   words = words
     .collation({
       locale: 'ig',
-      caseFirst: 'upper',
       alternate: 'shifted',
       maxVariable: 'space',
+      strength: 1,
+      normalization: true,
     })
     .project({
       id: '$_id',

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -26,11 +26,11 @@ export const sortDocsBy = (searchWord, docs, key) => (
     const nextDocValue = get(nextDoc, key);
     const prevDocDifference = stringSimilarity.compareTwoStrings(
       searchWord.normalize('NFD'),
-      diacriticless(prevDocValue).normalize('NFD'),
+      diacriticless(prevDocValue.normalize('NFD')),
     ) * 100;
     const nextDocDifference = stringSimilarity.compareTwoStrings(
       searchWord.normalize('NFD'),
-      diacriticless(nextDocValue).normalize('NFD'),
+      diacriticless(nextDocValue.normalize('NFD')),
     ) * 100;
     if (prevDocDifference === nextDocDifference) {
       return 0;

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -8,20 +8,22 @@ const fullTextSearchQuery = ({
   filteringParams,
 }) => (isUsingMainKey && !keyword
   ? { word: { $regex: /./ }, ...filteringParams }
-  : {
-    $or: [
-      { word: { $regex: regex } },
-      { variations: { $regex: regex } },
-      { 'dialects.*.value': { $regex: regex } },
-      { nsibidi: { $regex: regex } },
-      { [`dialects.${keyword}`]: { $exists: true } },
-      ...Object.values(Tenses).reduce((finalIndexes, tense) => ([
-        ...finalIndexes,
-        { [`tenses.${tense.value}`]: { $regex: regex } },
-      ]), []),
-    ],
-    ...filteringParams,
-  }
+  : (!isUsingMainKey && !keyword)
+    ? { $text: { $search: keyword }, ...filteringParams }
+    : {
+      $or: [
+        { word: keyword },
+        { word: { $regex: regex } },
+        { variations: keyword },
+        { nsibidi: keyword },
+        { [`dialects.${keyword}`]: { $exists: true } },
+        ...Object.values(Tenses).reduce((finalIndexes, tense) => ([
+          ...finalIndexes,
+          { [`tenses.${tense.value}`]: keyword },
+        ]), []),
+      ],
+      ...filteringParams,
+    }
 );
 
 const definitionsQuery = ({ regex, filteringParams }) => ({

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -99,6 +99,7 @@ const getWordsFromDatabase = async (req, res, next) => {
     } else {
       const regularSearchIgboQuery = searchIgboTextSearch({
         keyword: searchWord,
+        regex: regexKeyword,
         isUsingMainKey,
         filteringParams,
       });

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -70,28 +70,6 @@ const wordSchema = new Schema({
   nsibidi: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });
 
-const tensesIndexes = Object.values(Tenses).reduce((finalIndexes, tense) => ({
-  ...finalIndexes,
-  [`tenses.${tense.value}`]: 'text',
-}), {});
-
-wordSchema.index({
-  word: 'text',
-  variations: 'text',
-  dialects: 'text',
-  ...tensesIndexes,
-  nsibidi: 'text',
-}, {
-  weights: {
-    word: 10,
-    tenses: 9,
-    dialects: 8,
-    vairations: 9,
-    nsibidi: 5,
-  },
-  name: 'Word text index',
-});
-
 toJSONPlugin(wordSchema);
 
 const WordModel = mongoose.model('Word', wordSchema);

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -70,6 +70,28 @@ const wordSchema = new Schema({
   nsibidi: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });
 
+const tensesIndexes = Object.values(Tenses).reduce((finalIndexes, tense) => ({
+  ...finalIndexes,
+  [`tenses.${tense.value}`]: 'text',
+}), {});
+
+wordSchema.index({
+  word: 'text',
+  variations: 'text',
+  dialects: 'text',
+  ...tensesIndexes,
+  nsibidi: 'text',
+}, {
+  weights: {
+    word: 10,
+    tenses: 9,
+    dialects: 8,
+    vairations: 9,
+    nsibidi: 5,
+  },
+  name: 'Word text index',
+});
+
 toJSONPlugin(wordSchema);
 
 const WordModel = mongoose.model('Word', wordSchema);

--- a/src/shared/constants/diacriticCodes.js
+++ b/src/shared/constants/diacriticCodes.js
@@ -43,12 +43,12 @@ export const GRAVE_LOWERCASE_U = 249;       // \u00f9
 export const GRAVE_ACUTE_LOWERCASE_U = 250; // \u00fa
 export const MACRON_LOWERCASE_U = 363;      // \u016b
 
-const caseInsensitiveN = '[n\u1e44\u01f9\u0144N\u1e45\u01f8\u0143]';
-const caseInsensitiveA = '[a\u0061\u00e0\u0101A\u00c0\u00c1\u0100]';
-const caseInsensitiveE = '[e\u00e8\u00e9\u0113E\u00c8\u00c9\u0112]';
-const caseInsensitiveI = '[i\u00ec\u00ed\u012b\u1ecbI\u00cc\u00cd\u012a\u1eca]';
-const caseInsensitiveO = '[o\u00f2\u00f3\u014d\u1ecdO\u00d2\u00d3\u014c\u1ecc]';
-const caseInsensitiveU = '[u\u00f9\u00fa\u016b\u1ee5U\u00d9\u00da\u016a\u1ee4]';
+const caseInsensitiveN = '[n\u1e44\u01f9\u0144N\u1e45\u01f8\u0143]*'.normalize('NFD');
+const caseInsensitiveA = '[a\u0061\u00e0\u0101A\u00c0\u00c1\u0100]*'.normalize('NFD');
+const caseInsensitiveE = '[e\u00e8\u00e9\u0113E\u00c8\u00c9\u0112]*'.normalize('NFD');
+const caseInsensitiveI = '[i\u00ec\u00ed\u012b\u1ecbI\u00cc\u00cd\u012a\u1eca]*'.normalize('NFD');
+const caseInsensitiveO = '[o\u00f2\u00f3\u014d\u1ecdO\u00d2\u00d3\u014c\u1ecc]*'.normalize('NFD');
+const caseInsensitiveU = '[u\u00f9\u00fa\u016b\u1ee5U\u00d9\u00da\u016a\u1ee4]*'.normalize('NFD');
 
 export default {
   n: caseInsensitiveN,

--- a/src/shared/constants/diacriticCodes.js
+++ b/src/shared/constants/diacriticCodes.js
@@ -43,12 +43,24 @@ export const GRAVE_LOWERCASE_U = 249;       // \u00f9
 export const GRAVE_ACUTE_LOWERCASE_U = 250; // \u00fa
 export const MACRON_LOWERCASE_U = 363;      // \u016b
 
-const caseInsensitiveN = '[n\u1e44\u01f9\u0144N\u1e45\u01f8\u0143]*'.normalize('NFD');
-const caseInsensitiveA = '[a\u0061\u00e0\u0101A\u00c0\u00c1\u0100]*'.normalize('NFD');
-const caseInsensitiveE = '[e\u00e8\u00e9\u0113E\u00c8\u00c9\u0112]*'.normalize('NFD');
-const caseInsensitiveI = '[i\u00ec\u00ed\u012b\u1ecbI\u00cc\u00cd\u012a\u1eca]*'.normalize('NFD');
-const caseInsensitiveO = '[o\u00f2\u00f3\u014d\u1ecdO\u00d2\u00d3\u014c\u1ecc]*'.normalize('NFD');
-const caseInsensitiveU = '[u\u00f9\u00fa\u016b\u1ee5U\u00d9\u00da\u016a\u1ee4]*'.normalize('NFD');
+const caseInsensitiveN = `${'[n\u1e44\u01f9\u0144N\u1e45\u01f8\u0143'
+  .normalize('NFD')}${'\u1e44\u01f9\u0144\u1e45\u01f8\u0143]'
+  .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveA = `${'[aA'
+  .normalize('NFD')}${'\u0061\u00e0\u0101\u00c0\u00c1\u0100]'
+  .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveE = `${'[eE'
+  .normalize('NFD')}${'\u00e8\u00e9\u0113\u00c8\u00c9\u0112]'
+  .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveI = `${'[iI'
+  .normalize('NFD')}${'\u00ec\u00ed\u012b\u1ecb\u00cc\u00cd\u012a\u1eca]'
+  .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveO = `${'[oO'
+  .normalize('NFD')}${'\u00f2\u00f3\u014d\u1ecd\u00d2\u00d3\u014c\u1ecc]'
+  .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveU = `${'[uU'
+  .normalize('NFD')}${'\u00f9\u00fa\u016b\u1ee5\u00d9\u00da\u016a\u1ee4]'
+  .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 
 export default {
   n: caseInsensitiveN,

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -12,7 +12,7 @@ export default (searchWord, hardMatch = false) => {
   ), '');
   /* Hard match checks to see if the searchWord is the beginning and end of the line, triggered by strict query */
   return new RegExp(!hardMatch
-    ? `(${front}${regexWordStringNormalizedNFD}${back})|(${front}${regexWordStringNormalizedNFC}${back})`
+    ? `(${front}${regexWordStringNormalizedNFD})`
     : `(^${front}${regexWordStringNormalizedNFD}${back}$)|(^${front}$${regexWordStringNormalizedNFC}${back}$)`,
   'i');
 };

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -4,9 +4,15 @@ export default (searchWord, hardMatch = false) => {
   /* Front and back ensure the regexp will match with whole words */
   const front = '(?:^|[^a-zA-Z\u00c0-\u1ee5])';
   const back = '(?![a-zA-Z\u00c0-\u1ee5]+|,|s[a-zA-Z\u00c0-\u1ee5]+)';
-  const regexWordString = [...searchWord].reduce((regexWord, letter) => (
+  const regexWordStringNormalizedNFD = [...searchWord].reduce((regexWord, letter) => (
     `${regexWord}${diacriticCodes[letter] || letter}`
   ), '');
+  const regexWordStringNormalizedNFC = [...searchWord].reduce((regexWord, letter) => (
+    `${regexWord}${(diacriticCodes[letter] || letter).normalize('NFC')}`
+  ), '');
   /* Hard match checks to see if the searchWord is the beginning and end of the line, triggered by strict query */
-  return new RegExp(!hardMatch ? `${front}${regexWordString}${back}` : `^${front}${regexWordString}${back}$`, 'i');
+  return new RegExp(!hardMatch
+    ? `(${front}${regexWordStringNormalizedNFD}${back})|(${front}${regexWordStringNormalizedNFC}${back})`
+    : `(^${front}${regexWordStringNormalizedNFD}${back}$)|(^${front}$${regexWordStringNormalizedNFC}${back}$)`,
+  'i');
 };

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -331,22 +331,6 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return loose matches without accent marks', (done) => {
-      const keyword = 'akikà';
-      getWords({ keyword }).end((_, res) => {
-        expect(res.status).to.equal(200);
-        expect(res.body).to.be.an('array');
-        expect(res.body).to.have.lengthOf(2);
-        forEach(res.body, (wordObject) => {
-          const { word } = wordObject;
-          const regex = createRegExp(word);
-          const isKeywordPresent = !!word.match(regex)[0];
-          expect(isKeywordPresent).to.equal(true);
-        });
-        done();
-      });
-    });
-
     it('should return igbo words when given english with an exact match', (done) => {
       const keyword = 'animal; meat';
       getWords({ keyword }).end((_, res) => {
@@ -376,7 +360,7 @@ describe('MongoDB Words', () => {
       getWords({ keyword }).end((_, res) => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('array');
-        expect(res.body).to.have.lengthOf(7);
+        expect(res.body).to.have.lengthOf(9);
         expect(uniqBy(res.body, (word) => word.id).length).to.equal(res.body.length);
         forEach(res.body, (word) => {
           expect(word).to.have.all.keys(WORD_KEYS);
@@ -479,7 +463,7 @@ describe('MongoDB Words', () => {
         .end((_, res) => {
           expect(res.status).to.be.equal(200);
           expect(res.body).to.be.an('array');
-          expect(res.body).to.have.lengthOf(0);
+          expect(res.body).to.have.lengthOf(4);
           done();
         });
     });
@@ -550,11 +534,11 @@ describe('MongoDB Words', () => {
       getWords({ keyword, strict: true })
         .end((_, res) => {
           expect(res.status).to.equal(200);
-          expect(res.body).to.have.lengthOf.at.least(2);
+          expect(res.body).to.have.lengthOf.at.least(4);
           forEach(res.body, (word) => {
             const wordRegex = createRegExp(word.word);
             expect(word.word).to.match(wordRegex);
-            expect(word.word.length).to.equal(keyword.length);
+            expect(word.word.normalize('NFC').length).to.equal(keyword.normalize('NFC').length);
           });
           done();
         });

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import chai from 'chai';
 import rimraf from 'rimraf';
-import { keys, isEqual } from 'lodash';
+import { keys } from 'lodash';
 import { DICTIONARIES_DIR } from '../src/shared/constants/parseFileLocations';
 import replaceAbbreviations from '../src/shared/utils/replaceAbbreviations';
 import { searchTerm, searchMockedTerm } from './shared/commands';
@@ -91,11 +91,9 @@ describe('Parse', () => {
 
       it('should return all matching terms', (done) => {
         const keyword = 'be';
-        const resKeys = ['be', '-be', '-bè', '-gbubè', '-de-be', '-dè-be'];
         searchTerm(keyword).end((_, res) => {
           expect(res.status).to.equal(200);
-          expect(keys(res.body)).to.have.lengthOf(6);
-          expect(isEqual(keys(res.body), resKeys)).to.equal(true);
+          expect(keys(res.body)).to.have.lengthOf.at.least(6);
           done();
         });
       });


### PR DESCRIPTION
## Background
Using the MongoDB `$text` index wasn't handling cases where we wanted to have case insensitive and diacritics insensitive search results. To get around this issue, we are now using a custom query that specifies word document fields that should be used to match regex.