### PR TITLE
fix(search): pattern match whole words and sort words by definitions

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -104,6 +104,7 @@ export const findWordsWithMatch = async ({
       { $unset: `attributes.${WordAttributes.IS_BORROWED_TERM.value}` },
       { $unset: `attributes.${WordAttributes.IS_CONSTRUCTED_TERM.value}` },
     ])
+    .sort({ definitions: -1 })
     .skip(skip)
     .limit(limit);
 

--- a/src/middleware/analytics.js
+++ b/src/middleware/analytics.js
@@ -29,7 +29,7 @@ const trackEvent = ({
     }],
   });
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV === 'development') {
     axios({
       method: 'post',
       url: `${GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
@@ -46,10 +46,16 @@ const trackEvent = ({
       url: `${DEBUG_GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
       data,
     }).then((res) => {
-      console.log('Logging the data:', JSON.parse(data));
-      console.log('Google Analytics Debug res: ', res.data);
+      if (process.env.NODE_ENV === 'production') {
+        console.log('Logging the data:', JSON.parse(data));
+        console.log('Google Analytics Debug res: ', res.data);
+      }
     })
-      .catch((err) => console.log(typeof err?.toJSON === 'function' ? err.toJSON() : err));
+      .catch((err) => {
+        if (process.env.NODE_ENV === 'production') {
+          console.log(typeof err?.toJSON === 'function' ? err.toJSON() : err);
+        }
+      });
   }
 };
 

--- a/src/pages/components/Statistics/Statistics.js
+++ b/src/pages/components/Statistics/Statistics.js
@@ -42,7 +42,7 @@ const Statistics = ({
               {contributors.slice(0, 18)
                 .filter(({ login }) => login !== 'semantic-release-bot')
                 .map((contributor) => (
-                  <Tooltip label={`@${contributor.login}`}>
+                  <Tooltip key={contributor.login} label={`@${contributor.login}`}>
                     <div key={contributor.avatar_url}>
                       <a href={contributor.html_url}>
                         <img

--- a/src/services/words.js
+++ b/src/services/words.js
@@ -17,7 +17,7 @@ export const resultsFromDictionarySearch = (regexWord, word, dictionary) => (
     const currentMatchedResults = { ...matchedResults };
     const termInformation = dictionary[key];
     const trimmedKey = removePrefix(key);
-    const isTrimmedKeyAndWordSameLength = (trimmedKey.match(regexWord) && trimmedKey.length === word.length);
+    const isTrimmedKeyAndWordSameLength = trimmedKey.match(regexWord);
     if (isTrimmedKeyAndWordSameLength || doesVariationMatch(termInformation, regexWord)) {
       currentMatchedResults[key] = termInformation;
     }

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -4,15 +4,24 @@ export default (searchWord, hardMatch = false) => {
   /* Front and back ensure the regexp will match with whole words */
   const front = '(?:^|[^a-zA-Z\u00c0-\u1ee5])';
   const back = '(?![a-zA-Z\u00c0-\u1ee5]+|,|s[a-zA-Z\u00c0-\u1ee5]+)';
-  const regexWordStringNormalizedNFD = [...searchWord].reduce((regexWord, letter) => (
-    `${regexWord}${diacriticCodes[letter] || letter}`
-  ), '');
-  const regexWordStringNormalizedNFC = [...searchWord].reduce((regexWord, letter) => (
-    `${regexWord}${(diacriticCodes[letter] || letter).normalize('NFC')}`
-  ), '');
+  const regexWordStringNormalizedNFD = `${[...(searchWord
+    .replace(/(?:es|[s]|ing)$/, ''))]
+    .reduce((regexWord, letter) => (
+      `${regexWord}${diacriticCodes[letter] || letter}`
+    ), '')}(?:es|[sx]|ing)?`;
+  const regexWordStringNormalizedNFC = `${[...(searchWord
+    .replace(/(?:es|[s]|ing)$/, ''))]
+    .reduce((regexWord, letter) => (
+      `${regexWord}${(diacriticCodes[letter] || letter).normalize('NFC')}`
+    ), '')}(?:es|[sx]|ing)?`;
+
+  // const wordBoundary = `\\${searchWord.match(/[ \']/) ? 'B' : 'b'}`; // eslint-disable-line no-useless-escape
+  const startWordBoundary = '(\\W|^)';
+  const endWordBoundary = '(\\W|$)';
   /* Hard match checks to see if the searchWord is the beginning and end of the line, triggered by strict query */
   return new RegExp(!hardMatch
-    ? `(${front}${regexWordStringNormalizedNFD})`
-    : `(^${front}${regexWordStringNormalizedNFD}${back}$)|(^${front}$${regexWordStringNormalizedNFC}${back}$)`,
+    ? `${startWordBoundary}(${front}${regexWordStringNormalizedNFD})${endWordBoundary}`
+    : `${startWordBoundary}(^${front}${regexWordStringNormalizedNFD}${back}$)${endWordBoundary}`
+    + `|${startWordBoundary}(^${front}$${regexWordStringNormalizedNFC}${back}$)${endWordBoundary}`,
   'i');
 };

--- a/tests/api-json.test.js
+++ b/tests/api-json.test.js
@@ -30,7 +30,7 @@ describe('JSON Dictionary', () => {
       searchTerm(keyword).end((_, res) => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('object');
-        expect(res.body).to.have.keys(keyword);
+        expect(res.body).to.have.keys(['(agụū) -gụ', '-gụ agụū', 'agụū mmīli', keyword]);
         expect(res.body[keyword][0].wordClass).to.equal('NNC');
         done();
       });

--- a/tests/api-mongo.test.js
+++ b/tests/api-mongo.test.js
@@ -362,7 +362,7 @@ describe('MongoDB Words', () => {
       getWords({ keyword }).end((_, res) => {
         expect(res.status).to.equal(200);
         expect(res.body).to.be.an('array');
-        expect(res.body).to.have.lengthOf(9);
+        expect(res.body).to.have.lengthOf(6);
         expect(uniqBy(res.body, (word) => word.id).length).to.equal(res.body.length);
         forEach(res.body, (word) => {
           expect(word).to.have.all.keys(WORD_KEYS);
@@ -460,12 +460,12 @@ describe('MongoDB Words', () => {
     });
 
     it('should not return any words when wrapping an igbo word in quotes', (done) => {
-      const keyword = '"mmili"';
+      const keyword = '"ulo"';
       getWords({ keyword })
         .end((_, res) => {
           expect(res.status).to.be.equal(200);
           expect(res.body).to.be.an('array');
-          expect(res.body).to.have.lengthOf(4);
+          expect(res.body).to.have.lengthOf(0);
           done();
         });
     });


### PR DESCRIPTION
## Background
Updates search functionality so that:
* User inputted search words are matching with definitions as whole words
* Plural and present continuous (-ing) search terms match with their stems
* Matched documents are sorted in descending order based on the definition to ensure the best definition match appears at the top
## Helpful Resources
* [Why can't I use accented characters next to a word boundary?](https://stackoverflow.com/questions/2449779/why-cant-i-use-accented-characters-next-to-a-word-boundary)
* [Finding words in plural and singular when searching for plural word form in MongoDB](https://stackoverflow.com/questions/51321053/finding-words-in-plural-and-singular-when-searching-for-plural-word-form-in-mong)