### PR TITLE
fix(redis): save responses for dialects and examples

### DIFF
--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -95,7 +95,7 @@ const getWordsFromDatabase = async (req, res, next, redisClient) => {
     let query;
     const filteringParams = generateFilteringParams(wordFields);
     if (hasQuotes) {
-      const redisCacheKey = `"${searchWord}"-${skip}-${limit}`;
+      const redisCacheKey = `"${searchWord}"-${skip}-${limit}-${dialects}-${examples}`;
       const cachedWords = await redisClient.get(redisCacheKey);
       if (cachedWords) {
         words = cachedWords;
@@ -116,7 +116,7 @@ const getWordsFromDatabase = async (req, res, next, redisClient) => {
         : strictSearchIgboQuery(
           searchWord,
         );
-      const redisCacheKey = `${searchWord}-${skip}-${limit}`;
+      const redisCacheKey = `${searchWord}-${skip}-${limit}-${dialects}-${examples}`;
       const cachedWords = await redisClient.get(redisCacheKey);
       if (cachedWords) {
         words = cachedWords;


### PR DESCRIPTION
## Background
The Redis cache would save responses if the search word, skip value, and limit value existed collectively as a key. However, this wouldn't take into consideration the case where dialects and examples should be included in the response body.

This PR fixes this issue by including the boolean values for dialects and examples to determine if the response body should come from the cache or from MongoDB.