### PR TITLE
fix(redis): cut number of redis keys in half

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,8 @@
     "semi": ["error", "always"],
     "react/jsx-filename-extension": ["off"],
     "react/jsx-props-no-spreading": ["off"],
-    "react/no-danger": ["off"]
+    "react/no-danger": ["off"],
+    "@next/next/no-img-element": ["off"],
+    "@next/next/no-html-link-for-pages": ["off"]
   }
 }

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -115,20 +115,18 @@ const getWordsFromDatabase = async (req, res, next) => {
     const filteringParams = generateFilteringParams(wordFields);
     if (hasQuotes) {
       const redisWordsCacheKey = `"${searchWord}"-${skip}-${limit}-${version}-${dialects}-${examples}`;
-      const redisWordsCountCacheKey = `"${searchWord}-${version}"`;
-      const cachedWords = await redisClient.get(redisWordsCacheKey);
-      const cachedWordsCount = await redisClient.get(redisWordsCountCacheKey);
-      if (cachedWords && cachedWordsCount) {
-        words = cachedWords;
-        contentLength = cachedWordsCount;
+      const rawCachedWords = await redisClient.get(redisWordsCacheKey);
+      const cachedWords = typeof rawCachedWords === 'string' ? JSON.parse(rawCachedWords) : rawCachedWords;
+      if (cachedWords) {
+        words = cachedWords.words;
+        contentLength = cachedWords.contentLength;
       } else {
         query = searchEnglishRegexQuery({ regex, filteringParams });
         const wordsByEnglish = await searchWordUsingEnglish({ query, version, ...searchQueries });
         words = wordsByEnglish.words;
         contentLength = wordsByEnglish.contentLength;
         if (!redisClient.isFake) {
-          redisClient.set(redisWordsCacheKey, JSON.stringify(wordsByEnglish.words), 'EX', REDIS_CACHE_EXPIRATION);
-          redisClient.set(redisWordsCountCacheKey, `${wordsByEnglish.contentLength}`, 'EX', REDIS_CACHE_EXPIRATION);
+          redisClient.set(redisWordsCacheKey, JSON.stringify({ words, contentLength }), 'EX', REDIS_CACHE_EXPIRATION);
           redisClient.set(
             redisAllVerbsAndSuffixesKey,
             `${JSON.stringify(allVerbsAndSuffixes)}`,
@@ -154,20 +152,18 @@ const getWordsFromDatabase = async (req, res, next) => {
         : strictSearchIgboQuery(
           allSearchKeywords,
         );
-      const redisWordsCacheKey = `${searchWord}-${skip}-${limit}-${version}-${dialects}-${examples}`;
-      const redisWordsCountCacheKey = `${searchWord}-${version}`;
-      const cachedWords = await redisClient.get(redisWordsCacheKey);
-      const cachedWordsCount = await redisClient.get(redisWordsCountCacheKey);
-      if (cachedWords && cachedWordsCount) {
-        words = cachedWords;
-        contentLength = cachedWordsCount;
+    const redisWordsCacheKey = `${searchWord}-${skip}-${limit}-${version}-${dialects}-${examples}`;
+    const rawCachedWords = await redisClient.get(redisWordsCacheKey);
+    const cachedWords = typeof rawCachedWords === 'string' ? JSON.parse(rawCachedWords) : rawCachedWords;
+      if (cachedWords) {
+        words = cachedWords.words;
+        contentLength = cachedWords.contentLength;
       } else {
         const wordsByIgbo = await searchWordUsingIgbo({ query, version, ...searchQueries });
         words = wordsByIgbo.words;
         contentLength = wordsByIgbo.contentLength;
         if (!redisClient.isFake) {
-          redisClient.set(redisWordsCacheKey, JSON.stringify(wordsByIgbo.words), 'EX', REDIS_CACHE_EXPIRATION);
-          redisClient.set(redisWordsCountCacheKey, `${wordsByIgbo.contentLength}`, 'EX', REDIS_CACHE_EXPIRATION);
+          redisClient.set(redisWordsCacheKey, JSON.stringify({ words, contentLength }), 'EX', REDIS_CACHE_EXPIRATION);
           redisClient.set(
             redisAllVerbsAndSuffixesKey,
             JSON.stringify(allVerbsAndSuffixes),

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -152,9 +152,9 @@ const getWordsFromDatabase = async (req, res, next) => {
         : strictSearchIgboQuery(
           allSearchKeywords,
         );
-    const redisWordsCacheKey = `${searchWord}-${skip}-${limit}-${version}-${dialects}-${examples}`;
-    const rawCachedWords = await redisClient.get(redisWordsCacheKey);
-    const cachedWords = typeof rawCachedWords === 'string' ? JSON.parse(rawCachedWords) : rawCachedWords;
+      const redisWordsCacheKey = `${searchWord}-${skip}-${limit}-${version}-${dialects}-${examples}`;
+      const rawCachedWords = await redisClient.get(redisWordsCacheKey);
+      const cachedWords = typeof rawCachedWords === 'string' ? JSON.parse(rawCachedWords) : rawCachedWords;
       if (cachedWords) {
         words = cachedWords.words;
         contentLength = cachedWords.contentLength;


### PR DESCRIPTION
## Background
The Igbo API was generated twice the amount of necessary Redis caching keys. This cuts this total number in half by placing the Content-Length within the same body of words or examples in the cache.