### PR TITLE
feat(dialects): refactor dialects to be array of objects

### DIFF
--- a/__tests__/api-mongo.test.js
+++ b/__tests__/api-mongo.test.js
@@ -40,7 +40,12 @@ describe('MongoDB Words', () => {
           wordClass: 'NNC',
           definitions: ['first definition', 'second definition'],
         }],
-        dialects: {},
+        dialects: [{
+          variations: [],
+          dialects: ['NSA'],
+          pronunciation: '',
+          word: 'dialectalWord',
+        }],
         examples: [new ObjectId(), new ObjectId()],
         stems: [],
         tenses: {},
@@ -50,8 +55,13 @@ describe('MongoDB Words', () => {
       expect(savedWord.id).not.toEqual(undefined);
       expect(savedWord.word).toEqual('word');
       expect(savedWord.definitions[0].wordClass).toEqual('NNC');
-      expect(savedWord.dialects).not.toEqual(undefined);
       expect(savedWord.tenses).not.toEqual(undefined);
+      const wordRes = await getWord(savedWord.id, { dialects: true });
+      expect(wordRes.status).toEqual(200);
+      expect(wordRes.body.dialects.dialectalWord).not.toEqual(undefined);
+      const v2WordRes = await getWordV2(savedWord.id, { dialects: true });
+      expect(v2WordRes.status).toEqual(200);
+      expect(v2WordRes.body.dialects[0].word).toEqual('dialectalWord');
     });
 
     it('should fail populate mongodb with incorrect variations', async () => {
@@ -62,11 +72,10 @@ describe('MongoDB Words', () => {
           definitions: ['first definition', 'second definition'],
         }],
         dialects: {
-          dialectalWord: {
-            variations: [],
-            dialects: ['mismatch'],
-            pronunciation: '',
-          },
+          variations: [],
+          dialects: ['mismatch'],
+          pronunciation: '',
+          word: 'dialectalWord',
         },
         examples: [new ObjectId(), new ObjectId()],
         stems: [],
@@ -74,7 +83,7 @@ describe('MongoDB Words', () => {
       const validWord = new Word(word);
       await validWord.save()
         .catch((err) => {
-          expect(err.message.includes('`dialects`')).toEqual(true);
+          expect(err.message.includes('dialects')).toEqual(true);
         });
     });
 
@@ -513,7 +522,7 @@ describe('MongoDB Words', () => {
           wordClass: 'NNC',
           definitions: ['first definition', 'second definition'],
         }],
-        dialects: {},
+        dialects: [],
         examples: [new ObjectId(), new ObjectId()],
         attributes: {
           isStandardIgbo: true,
@@ -540,7 +549,7 @@ describe('MongoDB Words', () => {
           wordClass: 'NNC',
           definitions: ['first definition', 'second definition'],
         }],
-        dialects: {},
+        dialects: [],
         examples: [new ObjectId(), new ObjectId()],
         nsibidi: 'nsibidi',
         stems: [],
@@ -565,7 +574,7 @@ describe('MongoDB Words', () => {
           wordClass: 'NNC',
           definitions: ['first definition', 'second definition'],
         }],
-        dialects: {},
+        dialects: [],
         examples: [new ObjectId(), new ObjectId()],
         pronunciation: 'audio-pronunciation',
         stems: [],

--- a/migrations/20221107022314-resturcture-dialects-as-arrays.js
+++ b/migrations/20221107022314-resturcture-dialects-as-arrays.js
@@ -1,0 +1,82 @@
+const dialectsAsArraysPipeline = [
+  {
+    $match: {
+      dialects: {
+        $exists: true,
+      },
+    },
+  }, {
+    $set: {
+      dialects: {
+        $objectToArray: '$dialects',
+      },
+    },
+  }, {
+    $set: {
+      dialects: {
+        $function: {
+          // eslint-disable-next-line
+          body: 'function(dialects) {\n        return dialects.map(function ({ k, v }) {\n          v.word = k;\n          v._id = new ObjectId();\n          return v;\n        });\n      }', 
+          args: [
+            '$dialects',
+          ],
+          lang: 'js',
+        },
+      },
+    },
+  },
+];
+
+const dialectsAsObjectsPipeline = [
+  {
+    $match: {
+      dialects: {
+        $exists: true,
+      },
+    },
+  }, {
+    $set: {
+      dialects: {
+        $function: {
+          // eslint-disable-next-line
+          body: 'function(dialects) {\n        return dialects.reduce(function (finalObject, dialect) {\n          finalObject[dialect.word] = dialect;\n          return finalObject;\n        }, {});\n      }', 
+          args: [
+            '$dialects',
+          ],
+          lang: 'js',
+        },
+      },
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    const res = await Promise.all(collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(dialectsAsArraysPipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $set: { dialects: wordDoc.dialects } },
+        )
+      ))));
+    }));
+    return res;
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(dialectsAsObjectsPipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $set: { dialects: wordDoc.dialects } },
+        )
+      ))));
+    });
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -96,12 +96,16 @@ export const findWordsWithMatch = async ({
     if (version === Versions.VERSION_1) {
       word.wordClass = word.definitions[0].wordClass;
       word.definitions = flatten(word.definitions.map(({ definitions }) => definitions));
+      if (dialects) {
+        word.dialects = (word.dialects || []).reduce((finalDialects, dialect) => ({
+          ...finalDialects,
+          [dialect.word]: {
+            ...dialect,
+            dialects: dialect.dialects.map((d) => Dialects[d].label),
+          },
+        }), {});
+      }
     }
-    Object.keys(word?.dialects || {}).forEach((key) => {
-      word.dialects[key].dialects = (
-        word.dialects[key].dialects.map((dialect) => Dialects[dialect].label)
-      );
-    });
   });
   return { words: finalWords, contentLength };
 };

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -17,7 +17,7 @@ const fullTextSearchQuery = ({
         { 'definitions.definitions': { $in: [regex.definitionsReg] } },
         { variations: keyword },
         { nsibidi: keyword },
-        { [`dialects.${keyword}`]: { $exists: true } },
+        { 'dialects.word': keyword },
         ...Object.values(Tenses).reduce((finalIndexes, tense) => ([
           ...finalIndexes,
           { [`tenses.${tense.value}`]: keyword },

--- a/src/dictionaries/seed.js
+++ b/src/dictionaries/seed.js
@@ -26,13 +26,12 @@ const populate = async () => {
               definitions: word.definitions,
             },
           ];
-          word.dialects = {
-            [`${cleanedKey}-dialect`]: {
-              dialects: [Dialects.NSA.value],
-              variations: [],
-              pronunciation: '',
-            },
-          };
+          word.dialects = [{
+            dialects: [Dialects.NSA.value],
+            variations: [],
+            pronunciation: '',
+            word: `${cleanedKey}-dialect`,
+          }];
           return createWord(word);
         });
       }),


### PR DESCRIPTION
## Background
The `dialects` field will now be an array of objects for version 2 and a deeply nested object for version 1.