### PR TITLE
fix(stats): check if pronunciation is string before quering

### DIFF
--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -45,7 +45,7 @@ export const strictSearchIgboQuery = (word) => ({
 export const searchEnglishRegexQuery = definitionsQuery;
 
 export const searchForAllWordsWithAudioPronunciations = () => ({
-  pronunciation: { $exists: true },
+  pronunciation: { $exists: true, $type: 'string' },
   $expr: { $gt: [{ $strLenCP: '$pronunciation' }, 10] },
 });
 export const searchForAllWordsWithIsStandardIgbo = () => ({


### PR DESCRIPTION
## Background
The stats section has been broken, rendering only zeroes.