### PR TITLE
fix(package): use one node version

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
         mongodb-version: [4.0, 4.2]
       
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js v14
+      - name: Use Node.js v16
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install Node.js dependencies
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "test": "npm-run-all -p -r start:database jest"
   },
   "engines": {
-    "node": ">=14 <=16",
-    "npm": "6.x",
+    "node": "16",
+    "npm": "8",
     "yarn": "1.22.x"
   },
   "husky": {


### PR DESCRIPTION
## Background
Let's speed up the run time for running tests for the Igbo API by only running tests against Node v16