### PR TITLE
feat(attributes): release constructed terms

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -85,7 +85,6 @@ export const findWordsWithMatch = async ({
       .append([
         { $unset: `attributes.${WordAttributes.IS_COMPLETE.value}` },
         { $unset: `attributes.${WordAttributes.IS_BORROWED_TERM.value}` },
-        { $unset: `attributes.${WordAttributes.IS_CONSTRUCTED_TERM.value}` },
       ])
       .sort({ definitions: -1 });
 


### PR DESCRIPTION
## Background
Allow consumers for both v1 and v2 to have access to `attributes.isConstructedTerm`