### PR TITLE
feat(headword): add support for expanded headword fields

### DIFF
--- a/migrations/20221124200346-expand-headword.js
+++ b/migrations/20221124200346-expand-headword.js
@@ -1,0 +1,26 @@
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [
+        {
+          $set: {
+            wordPronunciation: '$word',
+            conceptualWord: '',
+          },
+        },
+      ])
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, [
+        {
+          $unset: ['wordPronunciation', 'conceptualWord'],
+        },
+      ])
+    ));
+  },
+};

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -27,6 +27,8 @@ const dialectSchema = new Schema({
 
 export const wordSchema = new Schema({
   word: { type: String, required: true },
+  wordPronunciation: { type: String, default: '' },
+  conceptualWord: { type: String, default: '' },
   definitions: [{
     type: definitionSchema,
     validate: (definitions) => (


### PR DESCRIPTION
## Background
Expand the `headword` into `wordPronunciation` and `conceptualWord` to avoid overloading the `headword`