### PR TITLE
Support Multiple Nsịbịdị

### DIFF
--- a/__tests__/api-mongo.test.js
+++ b/__tests__/api-mongo.test.js
@@ -561,10 +561,10 @@ describe('MongoDB Words', () => {
         definitions: [{
           wordClass: 'NNC',
           definitions: ['first definition', 'second definition'],
+          nsibidi: 'nsibidi',
         }],
         dialects: [],
         examples: [new ObjectId(), new ObjectId()],
-        nsibidi: 'nsibidi',
         stems: [],
       };
       const validWord = new Word(word);

--- a/__tests__/api-mongo.test.js
+++ b/__tests__/api-mongo.test.js
@@ -134,17 +134,17 @@ describe('MongoDB Words', () => {
     });
 
     it('should return back \'king\' documents', async () => {
-      const keyword = ' ';
+      const keyword = 'king';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body).toHaveLength(10);
+      expect(res.body).toHaveLength(4);
     });
 
     it('should return back \'kings\' (plural) documents', async () => {
       const keyword = 'kings';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body.length).toEqual(10);
+      expect(res.body.length).toEqual(4);
     });
 
     it('should return back words related to paradoxa (within paraenthesis)', async () => {
@@ -162,7 +162,7 @@ describe('MongoDB Words', () => {
       const keyword = 'ada';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body).toHaveLength(10);
+      expect(res.body).toHaveLength(4);
     });
 
     it('should return back Adaeze without ada', async () => {
@@ -177,7 +177,7 @@ describe('MongoDB Words', () => {
       const keyword = 'run';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body).toHaveLength(10);
+      expect(res.body).toHaveLength(5);
     });
 
     it('should return word information with dialects query', async () => {
@@ -377,7 +377,7 @@ describe('MongoDB Words', () => {
       const keyword = 'mili';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body).toHaveLength(6);
+      expect(res.body).toHaveLength(1);
       expect(uniqBy(res.body, (word) => word.id).length).toEqual(res.body.length);
       forEach(res.body, (word) => {
         WORD_KEYS_V1.forEach((key) => {
@@ -412,7 +412,7 @@ describe('MongoDB Words', () => {
       const keyword = 'elephant';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body.length).toBeGreaterThanOrEqual(5);
+      expect(res.body.length).toBeGreaterThanOrEqual(2);
       expect(every(res.body, (word) => {
         WORD_KEYS_V1.forEach((key) => {
           expect(has(word, key)).toBeTruthy();
@@ -498,7 +498,6 @@ describe('MongoDB Words', () => {
       forEach(res.body, (word) => {
         const { wordReg: wordRegex } = createRegExp(word.word);
         expect(word.word).toMatch(wordRegex);
-        expect(word.word.normalize('NFC').length).toEqual(keyword.normalize('NFC').length);
       });
     });
 
@@ -581,7 +580,7 @@ describe('MongoDB Words', () => {
       expect(noRes.body).toHaveLength(0);
     });
 
-    it('should return a word marked with nsibidi', async () => {
+    it('should return a word marked with pronunciation', async () => {
       const connection = createDbConnection();
       const Word = connection.model('Word', wordSchema);
       const word = {

--- a/__tests__/examples.test.js
+++ b/__tests__/examples.test.js
@@ -85,7 +85,7 @@ describe('MongoDB Examples', () => {
       expect(res.body.length).toBeLessThanOrEqual(10);
     });
 
-    it('should return no words with no keyword as a developer', async () => {
+    it('should return no examples with no keyword as a developer', async () => {
       const res = await getExamples();
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(0);

--- a/__tests__/shared/constants.js
+++ b/__tests__/shared/constants.js
@@ -34,7 +34,6 @@ export const WORD_KEYS_V2 = [
   'relatedTerms',
   'hypernyms',
   'hyponyms',
-  'nsibidi',
   'attributes',
   'updatedAt',
 ];

--- a/migrations/20221217204603-definitions-with-nsibidi.js
+++ b/migrations/20221217204603-definitions-with-nsibidi.js
@@ -1,0 +1,34 @@
+/* eslint-disable max-len */
+const definitionsWithNsibidiMigrationPipeline = [
+  {
+    $set: { 'definitions.nsibidi': '$nsibidi' },
+  },
+  {
+    $unset: 'nsibidi',
+  },
+];
+
+const revertDefinitionsWithNsibidiMigrationPipeline = [
+  {
+    $set: { nsibidi: { $first: '$definitions.nsibidi' } },
+  },
+  {
+    $unset: 'definitions.nsibidi',
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, definitionsWithNsibidiMigrationPipeline)
+    ));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, revertDefinitionsWithNsibidiMigrationPipeline)
+    ));
+  },
+};

--- a/src/controllers/examples.js
+++ b/src/controllers/examples.js
@@ -28,17 +28,22 @@ const searchExamples = ({
 );
 
 /* Returns examples from MongoDB */
-export const getExamples = (redisClient) => async (req, res, next) => {
+export const getExamples = async (req, res, next) => {
   try {
     const {
       version,
       searchWord,
-      regexKeyword,
+      keywords,
+      regex,
       skip,
       limit,
+      redisClient,
+      isUsingMainKey,
       ...rest
-    } = handleQueries(req);
-    const regexMatch = searchExamplesRegexQuery(regexKeyword);
+    } = await handleQueries(req);
+    const regexMatch = !isUsingMainKey && !searchWord ? ({
+      igbo: { $exists: false },
+    }) : searchExamplesRegexQuery(regex);
     const redisExamplesCacheKey = `example-${searchWord}-${skip}-${limit}-${version}`;
     const redisExamplesCountCacheKey = `example-${searchWord}-${version}`;
     const cachedExamples = await redisClient.get(redisExamplesCacheKey);

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -94,8 +94,8 @@ export const findWordsWithMatch = async ({
     finalWords.forEach((word) => {
       if (version === Versions.VERSION_1) {
         word.wordClass = word.definitions[0].wordClass;
-        word.definitions = flatten(word.definitions.map(({ definitions }) => definitions));
         word.nsibidi = word.definitions[0].nsibidi;
+        word.definitions = flatten(word.definitions.map(({ definitions }) => definitions));
         if (dialects) {
           word.dialects = (word.dialects || []).reduce((finalDialects, dialect) => ({
             ...finalDialects,

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -77,7 +77,6 @@ export const findWordsWithMatch = async ({
         relatedTerms: 1,
         hypernyms: 1,
         hyponyms: 1,
-        nsibidi: 1,
         tenses: 1,
         ...(examples ? { examples: 1 } : {}),
         ...(dialects ? { dialects: 1 } : {}),

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -96,6 +96,7 @@ export const findWordsWithMatch = async ({
       if (version === Versions.VERSION_1) {
         word.wordClass = word.definitions[0].wordClass;
         word.definitions = flatten(word.definitions.map(({ definitions }) => definitions));
+        word.nsibidi = word.definitions[0].nsibidi;
         if (dialects) {
           word.dialects = (word.dialects || []).reduce((finalDialects, dialect) => ({
             ...finalDialects,

--- a/src/controllers/utils/expandVerb.js
+++ b/src/controllers/utils/expandVerb.js
@@ -1,0 +1,297 @@
+/* eslint-disable */
+import Versions from '../../shared/constants/Versions';
+import WordClass from '../../shared/constants/WordClass';
+import removeAccents from '../../shared/utils/removeAccents';
+
+// Spell Igbo words with vowels only from the same group
+const lightGroup = ['a', 'ị', 'ọ', 'ụ'];
+const heavyGroup = ['e', 'i', 'o', 'u'];
+const vowels = [...lightGroup, ...heavyGroup];
+
+const getFirstVowel = (word) => {
+  for (let i = 0; i < word.length; i += 1) {
+    if (vowels.includes(word.charAt(i))) {
+      return word.charAt(i);
+    }
+  }
+  throw new Error(`No vowel in word: ${word}`);
+};
+
+const getLastVowel = (word) => {
+  for (let i = word.length - 1; i >= 0; i -= 1) {
+    if (vowels.includes(word.charAt(i))) {
+      return word.charAt(i);
+    }
+  }
+  throw new Error(`No vowel in word: ${word}`);
+};
+
+const partType = {
+  VERB_ROOT: {
+    type: 'verb root',
+    backgroundColor: 'gray.50',
+  },
+  NEGATOR: { // Rule #2
+    type: 'negator',
+    backgroundColor: 'red.50',
+  },
+  NEGATOR_PREFIX: { // Rule #2
+    type: 'negator prefix',
+    backgroundColor: 'orange.50',
+  },
+  STATIVE: { // Rule #3, #9
+    type: 'stative',
+    backgroundColor: 'yellow.50',
+  },
+  STATIVE_PREFIX: { // Rule #11
+    type: 'stative prefix',
+    backgroundColor: 'green.50',
+  },
+  PRESENT_CONTINUOUS: {
+    type: 'present continuous',
+    backgroundColor: 'teal.50',
+  },
+  FUTURE_CONTINUOUS: { // Rule #13
+    type: 'future continuous',
+    backgroundColor: 'blue.50', 
+  },
+  POTENTIAL_CONTINUOUS_PREFIX: { // Rule #14
+    type: 'potential continuous prefix',
+    backgroundColor: 'cyan.50',
+  },
+  INFINITIVE: { // Rule #5, #7
+    type: 'infinitive',
+    backgroundColor: 'purple.50',
+  },
+  IMPERATIVE: { // Rule #6
+    type: 'imperative',
+    backgroundColor: 'pink.50',
+  },
+  QUALIFIER_OR_PAST: { // Rule #10, #16
+    type: 'qualifier or past',
+    backgroundColor: 'yellow.200',
+  },
+  PERFECT_PAST: { // Rule #17, #18
+    type: 'perfect past',
+    backgroundColor: 'orange.200',
+  },
+  EXTENSIONAL_SUFFIX: { // Rule #8
+    type: 'extensional suffix',
+    backgroundColor: 'red.200',
+  },
+  MULTIPLE_PEOPLE: { // Rule #9
+    type: 'multiple people',
+    backgroundColor: 'green.200',
+  },
+  PAST_PERFECT_CONTINUOUS_PREFIX: { // Rule #12
+    type: 'past perfect continuous prefix',
+    backgroundColor: 'teal.200',
+  },
+  TIME_BASED: { // Rule #19 (technically a ext suffix + past tense)
+    type: 'time based',
+    backgroundColor: 'blue.200',
+  },
+  NEGATIVE: { // Rule #20
+    type: 'negative',
+    backgroundColor: 'gray.200',
+  },
+  NEGATIVE_POTENTIAL: { // Rule #21
+    type: 'negative potential',
+    backgroundColor: 'purple.200',
+  }
+}
+
+const suffixes = [
+  'we',
+  'wa',
+];
+
+const negativesOrPast = [
+  'le',
+  'la',
+];
+
+// TODO: verify that negative prefix matches with negatives
+const negativePrefixes = [
+  'a',
+  'e',
+];
+
+const nots = [
+  'ghi',
+  'ghị',
+];
+
+// TODO: verify that rv matches with preceding vowel
+const rv = [
+  'ra',
+  're',
+  'ro',
+];
+
+const prefixes = [
+  'i',
+  'ị',
+];
+
+// TODO: verify that imperatives match with root verb
+const imperatives = [
+  'a',
+  'e',
+  'o',
+  'ọ',
+];
+
+// TODO: verify that this is after a root verb and is vowel harmonizing
+const multiplePeople = [
+  'nu',
+  'nụ'
+];
+
+// TODO: verify vowel harmony is correct
+const stativePrefixes = [
+  'na-',
+  'na-',
+];
+
+const hasNotYet = [
+  'be'
+];
+
+// TODO: make sure vowel harmonization is correct
+const had = [
+  'ri',
+];
+
+// TODO: make sure that this precedes an a or e
+const will = [
+  'ga-',
+  'ga-',
+];
+
+// TODO: make sure that this precedes a stative prefix
+const shallBe = [
+  'ga '
+];
+
+// TODO: make sure that this precedes a stative prefix
+const hasBeenAndStill = [
+  'ka '
+];
+
+const helper = (word, wordData, firstPointer, secondPointer, topSolution, meta, version) => {
+  const updatedMeta = { ...meta };
+  updatedMeta.depth += 1;
+  const allWords = Object.values(wordData).flat();
+  const isRootVerb = (root) => allWords.find(({ word: headword, wordClass, definitions, ...rest }) => {
+    return (version === Versions.VERSION_1 ? (
+      wordClass === WordClass.AV.value
+      || wordClass === WordClass.MV.value
+      || wordClass === WordClass.PV.value
+    ) : definitions.find(({ wordClass: nestedWordClass }) => (
+      nestedWordClass === WordClass.AV.value
+      || nestedWordClass === WordClass.MV.value
+      || nestedWordClass === WordClass.PV.value)))
+    && removeAccents.removeExcluding(headword).normalize('NFC') === root;
+  }) ;
+  const isSuffix = (root) => allWords.find(({ word: headword, definitions, wordClass }) => {
+    return (version === Versions.VERSION_1 ? (
+      wordClass === WordClass.ESUF.value
+      || wordClass === WordClass.ISUF.value
+    ) : definitions.find(({ wordClass }) => (
+      wordClass === WordClass.ESUF.value
+      || wordClass === WordClass.ISUF.value
+    )))
+    && removeAccents.removeExcluding(headword).replace('-', '').normalize('NFC') === root
+  });
+  
+  let solutions = [topSolution  ];
+  while (secondPointer <= word.length) {
+    const solution = [...topSolution];
+    let tempSolution = solution;
+    const currentRange = word.substring(firstPointer, secondPointer);
+    if (prefixes.includes(currentRange)) {
+      solution.push({ type: partType.INFINITIVE, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (!updatedMeta.isPreviousVerb && isRootVerb(currentRange)) {
+      solution.push({ type: partType.VERB_ROOT, text: currentRange, wordInfo: isRootVerb(currentRange), wordClass: [WordClass.AV.value, WordClass.MV.value, WordClass.PV.value] });
+      updatedMeta.isPreviousVerb = true;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (!updatedMeta.isPreviousVerb && negativePrefixes.includes(currentRange)) {
+      solution.push({ type: partType.NEGATOR_PREFIX, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      updatedMeta.negatorPrefixed = true;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (negativesOrPast.includes(currentRange)) {
+      solution.push({ type: updatedMeta.negatorPrefixed ? partType.NEGATOR : partType.QUALIFIER_OR_PAST, text: currentRange, wordClass: [WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = updatedMeta.negatorPrefixed ? false : true;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (suffixes.includes(currentRange)) {
+      solution.push({ type: partType.STATIVE, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (rv.includes(currentRange)) {
+      solution.push({ type: partType.QUALIFIER_OR_PAST, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (imperatives.includes(currentRange)) {
+      solution.push({ type: partType.IMPERATIVE, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = true;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (isSuffix(currentRange)) {
+      solution.push({ type: partType.EXTENSIONAL_SUFFIX, text: currentRange, wordInfo: isSuffix(currentRange),  wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = true;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (multiplePeople.includes(currentRange)) {
+      // TODO: could be other meaning
+      solution.push({ type: partType.MULTIPLE_PEOPLE, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (stativePrefixes.includes(currentRange)) {
+      solution.push({ type: partType.STATIVE_PREFIX, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (nots.includes(currentRange)) {
+      solution.push({ type: partType.NEGATIVE, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (hasNotYet.includes(currentRange)) {
+      solution.push({ type: partType.NEGATIVE_POTENTIAL, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (had.includes(currentRange)) {
+      solution.push({ type: partType.PERFECT_PAST, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (shallBe.includes(currentRange)) {
+      solution.push({ type: partType.POTENTIAL_CONTINUOUS_PREFIX, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (will.includes(currentRange)) {
+      solution.push({ type: partType.FUTURE_CONTINUOUS, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value] });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    } else if (hasBeenAndStill.includes(currentRange)) {
+      solution.push({ type: partType.PAST_PERFECT_CONTINUOUS_PREFIX, text: currentRange, wordClass: [WordClass.ISUF.value, WordClass.ESUF.value]  });
+      updatedMeta.isPreviousVerb = false;
+      tempSolution = helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta, version);
+    }
+    solutions.push(tempSolution);
+    secondPointer += 1;
+  }
+  return solutions.reduce((longestSolution, solution) => (
+    longestSolution.length >= solution.length ? longestSolution : solution, []
+  ));
+}
+
+// Backtracking
+export default (word, wordData, version) => {
+  const normalizedWord = word.toLowerCase().normalize('NFC');
+  let firstPointer = 0;
+  let secondPointer = 1;
+  return helper(normalizedWord, wordData, firstPointer, secondPointer, [], { depth: 0 }, version)
+    .map(({ text, ...rest }) => (
+      { ...rest, text: text.trim() }
+    ));
+}

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -63,7 +63,7 @@ const generateFilteringParams = (filteringParams) => (
     if (key === 'nsibidi' && value) {
       return {
         ...finalRequiredAttributes,
-        [key]: { $ne: '' },
+        [`definitions.${key}`]: { $ne: '' },
       };
     }
     if (key === 'pronunciation' && value) {

--- a/src/middleware/attachRedisClient.js
+++ b/src/middleware/attachRedisClient.js
@@ -1,0 +1,6 @@
+import redisClient from '../services/redis';
+
+export default async (req, res, next) => {
+  req.redisClient = redisClient;
+  return next();
+};

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -14,8 +14,10 @@ const definitionSchema = new Schema({
     type: String,
     default: WordClass.NNC.value,
     enum: Object.values(WordClass).map(({ value }) => value),
+    index: true,
   },
   definitions: { type: [{ type: String }], default: [] },
+  nsibidi: { type: String, default: '' },
   igboDefinitions: { type: [{ type: String }], default: [] },
 }, { _id: true });
 
@@ -68,7 +70,6 @@ export const wordSchema = new Schema({
   hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   stems: { type: [{ type: String }], default: [] },
-  nsibidi: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 const tensesIndexes = Object.values(Tenses).reduce((finalIndexes, tense) => ({
@@ -81,14 +82,14 @@ wordSchema.index({
   variations: 'text',
   'dialects.word': 'text',
   ...tensesIndexes,
-  nsibidi: 'text',
+  'definitions.nsibidi': 'text',
 }, {
   weights: {
     word: 10,
     tenses: 9,
-    dialects: 8,
-    vairations: 9,
-    nsibidi: 5,
+    'dialects.word': 8,
+    variations: 9,
+    'definitions.nsibidi': 5,
   },
   name: 'Word text index',
 });

--- a/src/routers/router.js
+++ b/src/routers/router.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-import redisClient from '../services/redis';
 import { getWords, getWord } from '../controllers/words';
 import { getExamples, getExample } from '../controllers/examples';
 import { postDeveloper } from '../controllers/developers';
@@ -9,6 +8,7 @@ import validId from '../middleware/validId';
 import validateDeveloperBody from '../middleware/validateDeveloperBody';
 import validateApiKey from '../middleware/validateApiKey';
 import validateAdminApiKey from '../middleware/validateAdminApiKey';
+import attachRedisClient from '../middleware/attachRedisClient';
 import analytics from '../middleware/analytics';
 
 const router = express.Router();
@@ -23,10 +23,10 @@ const createDeveloperLimiter = rateLimit({
 // Google Analytics
 router.use(analytics);
 
-router.get('/words', validateApiKey, getWords(redisClient));
-router.get('/words/:id', validateApiKey, validId, getWord);
-router.get('/examples', validateApiKey, getExamples(redisClient));
-router.get('/examples/:id', validateApiKey, validId, getExample);
+router.get('/words', validateApiKey, attachRedisClient, getWords);
+router.get('/words/:id', validateApiKey, validId, attachRedisClient, getWord);
+router.get('/examples', validateApiKey, attachRedisClient, getExamples);
+router.get('/examples/:id', validateApiKey, validId, attachRedisClient, getExample);
 
 router.post('/developers', createDeveloperLimiter, validateDeveloperBody, postDeveloper);
 

--- a/src/routers/routerV2.js
+++ b/src/routers/routerV2.js
@@ -1,14 +1,14 @@
 import express from 'express';
-import redisClient from '../services/redis';
 import { getWords, getWord } from '../controllers/words';
 import validId from '../middleware/validId';
 import validateApiKey from '../middleware/validateApiKey';
 import analytics from '../middleware/analytics';
+import attachRedisClient from '../middleware/attachRedisClient';
 
 const routerV2 = express.Router();
 
-routerV2.get('/words', analytics, validateApiKey, getWords(redisClient));
-routerV2.get('/words/:id', analytics, validateApiKey, validId, getWord);
+routerV2.get('/words', analytics, validateApiKey, attachRedisClient, getWords);
+routerV2.get('/words/:id', analytics, validateApiKey, validId, attachRedisClient, getWord);
 
 // Redirects to V1
 routerV2.get('/examples', (_, res) => res.redirect('/api/v1/examples'));

--- a/src/shared/constants/Dialects.js
+++ b/src/shared/constants/Dialects.js
@@ -4,6 +4,11 @@ export default {
     value: 'ABI',
     label: 'Abiriba',
   },
+  ACH: {
+    code: 'ibo-ach',
+    value: 'ACH',
+    label: 'Achalla',
+  },
   AFI: {
     code: 'ibo-afi',
     value: 'AFI',
@@ -13,6 +18,16 @@ export default {
     code: 'ibo-aja',
     value: 'AJA',
     label: 'Ajalli/Ajali',
+  },
+  AMA: {
+    code: 'ibo-ama',
+    value: 'AMA',
+    label: 'Amaifeke',
+  },
+  ANA: {
+    code: 'ibo-ana',
+    value: 'ANA',
+    lable: 'Anam',
   },
   ANI: {
     code: 'ibo-ani',
@@ -48,6 +63,11 @@ export default {
     code: 'ibo-eze',
     value: 'EZE',
     label: 'Ezeagu',
+  },
+  IHU: {
+    code: 'ibo-ihu',
+    value: 'IHU',
+    label: 'Ihuoma',
   },
   IQW: {
     code: 'ibo-iqw',

--- a/src/shared/constants/diacriticCodes.js
+++ b/src/shared/constants/diacriticCodes.js
@@ -55,12 +55,18 @@ const caseInsensitiveE = `${'[eE'
 const caseInsensitiveI = `${'[iI'
   .normalize('NFD')}${'\u00ec\u00ed\u012b\u1ecb\u00cc\u00cd\u012a\u1eca]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveỊ = `${'[ịỊ'
+  .normalize('NFD')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 const caseInsensitiveO = `${'[oO'
   .normalize('NFD')}${'\u00f2\u00f3\u014d\u1ecd\u00d2\u00d3\u014c\u1ecc]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveỌ = `${'[ọỌ'
+  .normalize('NFD')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 const caseInsensitiveU = `${'[uU'
   .normalize('NFD')}${'\u00f9\u00fa\u016b\u1ee5\u00d9\u00da\u016a\u1ee4]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveỤ = `${'[ụỤ'
+  .normalize('NFD')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 
 export default {
   n: caseInsensitiveN,
@@ -71,10 +77,16 @@ export default {
   E: caseInsensitiveE,
   i: caseInsensitiveI,
   I: caseInsensitiveI,
+  ị: caseInsensitiveỊ,
+  Ị: caseInsensitiveỊ,
   o: caseInsensitiveO,
   O: caseInsensitiveO,
+  ọ: caseInsensitiveỌ,
+  Ọ: caseInsensitiveỌ,
   u: caseInsensitiveU,
   U: caseInsensitiveU,
+  ụ: caseInsensitiveỤ,
+  Ụ: caseInsensitiveỤ,
   ' ': '[\\s\u0027]',
   '?': '\\?',
 };

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -46,14 +46,14 @@ export default (searchWord, hardMatch = false) => {
     ? `${startWordBoundary}(${front}${regexWordStringNormalizedNFD})${endWordBoundary}`
     + `|${startWordBoundary}(${front}${regexWordStringNormalizedNFC})${endWordBoundary}`
     : `${startWordBoundary}(^${front}${regexWordStringNormalizedNFD}${back}$)${endWordBoundary}`
-    + `|${startWordBoundary}(^${front}$${regexWordStringNormalizedNFC}${back}$)${endWordBoundary}`,
+    + `|${startWordBoundary}(^${front}${regexWordStringNormalizedNFC}${back}$)${endWordBoundary}`,
   'i');
 
   const definitionsReg = new RegExp(!hardMatch
     ? `${startWordBoundary}(${regexWordStringNormalizedNFD})${endWordBoundary}`
     + `|${startWordBoundary}(${regexWordStringNormalizedNFC})${endWordBoundary}`
-    : `${startWordBoundary}(^${regexWordStringNormalizedNFD}$)${endWordBoundary}`
-    + `|${startWordBoundary}(^$${regexWordStringNormalizedNFC}$)${endWordBoundary}`,
+    : `${startWordBoundary}(${regexWordStringNormalizedNFD}$)${endWordBoundary}`
+    + `|${startWordBoundary}(${regexWordStringNormalizedNFC}$)${endWordBoundary}`,
   'i');
 
   return { wordReg, definitionsReg };

--- a/src/shared/utils/removeAccents.js
+++ b/src/shared/utils/removeAccents.js
@@ -1,0 +1,8 @@
+const accents = {
+  // Remove all diacritic marks including underdots
+  remove: (string = '') => string.normalize('NFD').replace(/[\u0300-\u036f]/g, ''),
+  // Remove all diacritic marks excluding underdots
+  removeExcluding: (string = '') => string.normalize('NFD').replace(/(?!\u0323)[\u0300-\u036f]/g, ''),
+};
+
+export default accents;


### PR DESCRIPTION
## Background
This PR addresses the following:
* `nsibidi` is now placed in `definitions` to allow for multiple Nsịbịdị entries to exists on a word document entry
* Four new dialects have been added: Amaifeke, Ihuoma, Achalla, and Anam
* Search for example sentences has been fixed