### PR TITLE
chore: stop copying yarn.lock file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16
 
 WORKDIR /app
 
-COPY package.json yarn.lock ./
+COPY package.json ./
 
 RUN yarn install
 


### PR DESCRIPTION
## Background
Fixes the `dockerize.yml` GitHub Action by avoiding copying the now non-existent `yarn.lock` file