### PR TITLE
Conditionally Check Underdots

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:assets": "shx cp -r ./src/pages/assets/ ./build/dist/assets",
     "start:emulators": "node_modules/.bin/firebase emulators:start --only functions,hosting",
     "clean": "shx rm -rf node_modules/ build/ out/ yarn.lock package-lock.json *.log",
+    "predev": "kill -9 $(lsof -t -i:8080)",
     "dev": "npm-run-all -p start:emulators start:database",
     "dev:full": "firebase functions:config:set env.redis_url=redis://localhost:6379 env.replica_set=true env.redis_status=true && npm-run-all -p start:emulators start:database:replica",
     "migrate-up": "migrate-mongo up",

--- a/src/middleware/analytics.js
+++ b/src/middleware/analytics.js
@@ -4,8 +4,6 @@ import {
   GA_API_SECRET,
   GA_URL,
   DEBUG_GA_URL,
-  isDevelopment,
-  isProduction,
 } from '../config';
 
 const trackEvent = ({
@@ -18,6 +16,7 @@ const trackEvent = ({
     measurement_id: GA_TRACKING_ID,
     api_secret: GA_API_SECRET,
   };
+  const isProduction = !process.env.FUNCTIONS_EMULATOR && params.GA_TRACKING_ID && params.GA_API_SECRET;
 
   const data = JSON.stringify({
     client_id: clientIdentifier,
@@ -31,7 +30,8 @@ const trackEvent = ({
     }],
   });
 
-  if (!isDevelopment) {
+  // Avoid sending GA events
+  if (isProduction) {
     axios({
       method: 'post',
       url: `${GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
@@ -47,11 +47,6 @@ const trackEvent = ({
       method: 'post',
       url: `${DEBUG_GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
       data,
-    }).then((res) => {
-      if (isProduction) {
-        console.log('Logging the data:', JSON.parse(data));
-        console.log('Google Analytics Debug res: ', res.data);
-      }
     })
       .catch((err) => {
         if (isProduction) {

--- a/src/shared/constants/diacriticCodes.js
+++ b/src/shared/constants/diacriticCodes.js
@@ -52,13 +52,13 @@ const caseInsensitiveE = `${'[eE'}${'\u00e8\u00e9\u0113\u00c8\u00c9\u0112]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 const caseInsensitiveI = `${'[iI'}${'\u00ec\u00ed\u012b\u1ecb\u00cc\u00cd\u012a\u1eca]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
-const caseInsensitiveỊ = `${'(([iI]+[\u0323])|[\u1ECB\u1ECA])'}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveỊ = `${'(([iI]+[\u0323]{0,})|[\u1ECB\u1ECA])'}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 const caseInsensitiveO = `${'[oO'}${'\u00f2\u00f3\u014d\u1ecd\u00d2\u00d3\u014c\u1ecc]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
-const caseInsensitiveỌ = `${'(([oO]+[\u0323])|[\u1ECD\u1ECC])'}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveỌ = `${'(([oO]+[\u0323]{0,})|[\u1ECD\u1ECC])'}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 const caseInsensitiveU = `${'[uU'}${'\u00f9\u00fa\u016b\u1ee5\u00d9\u00da\u016a\u1ee4]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
-const caseInsensitiveỤ = `${'(([uU]+[\u0323])|[\u1EE5\u1EE4])'}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
+const caseInsensitiveỤ = `${'(([uU]+[\u0323]{0,})|[\u1EE5\u1EE4])'}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;
 
 export default {
   n: caseInsensitiveN,


### PR DESCRIPTION
## Background
Despite the dataset including the word "secretary" as "òdeākwụ̄kwọ̄", when searched with "ọdeakwụkwọ", the word wouldn't be returned. This was happening because in order for the word to match, it needed the underdot of the first o to be present. However, that's too restrictive for many searches and could apply to hundreds of other word searches.

This PR loosens the search so that it doesn't require an underdot to be present in order to match with the word.

Additionally, this PR removes unnecessary analytics logs along with adding a predev step to help clear out port 8080