### PR TITLE
chore: fix semantic release by bumping node to v18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - name: Use Node.js v16
+    - name: Use Node.js v18
       uses: actions/setup-node@v1
       with:
-        node-version: 16
+        node-version: 18
     - name: Install Dependencies
       run: yarn install
     - name: Release


### PR DESCRIPTION
## Background
Bump `semantic-released` Node version to 18 so that the GitHub Actions Release action works as expected.

Semantic Release Node requirement specification: https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md