### PR TITLE
chore: set development environment when running yarn dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:assets": "shx cp -r ./src/pages/assets/ ./build/dist/assets",
     "start:emulators": "node_modules/.bin/firebase emulators:start --only functions,hosting",
     "clean": "shx rm -rf node_modules/ build/ out/ yarn.lock package-lock.json *.log",
+    "predev": "firebase functions:config:set runtime.env=development",
     "dev": "npm-run-all -p start:emulators start:database",
     "dev:full": "firebase functions:config:set env.redis_url=redis://localhost:6379 env.replica_set=true env.redis_status=true && npm-run-all -p start:emulators start:database:replica",
     "migrate-up": "migrate-mongo up",


### PR DESCRIPTION
## Background
The `predev` script will set the Firebase environment to "development"