### PR TITLE
fix: use index of search word in definitions to improve sorting relevancy

### DIFF
--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -43,8 +43,6 @@ const generateAggregationBase = (Model, match) => (
 export const findWordsWithMatch = async ({
   match,
   version,
-  skip = 0,
-  limit = 10,
   dialects,
   examples,
 }) => {
@@ -86,9 +84,8 @@ export const findWordsWithMatch = async ({
       ])
       .sort({ definitions: -1 });
 
-    const allWords = examples ? removeKeysInNestedDoc(await words, 'examples') : await words;
-    const contentLength = allWords.length;
-    const finalWords = allWords.slice(skip, skip + limit);
+    const finalWords = examples ? removeKeysInNestedDoc(await words, 'examples') : await words;
+    const contentLength = finalWords.length;
 
     finalWords.forEach((word) => {
       if (version === Versions.VERSION_1) {

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -15,18 +15,30 @@ export default (rawSearchWord, hardMatch = false) => {
   const requirePluralAndGerundMatch = searchWord.endsWith('ing') && searchWord.replace('ing', '').length <= 1
     ? ''
     : '?';
-  let regexWordString = [...(searchWord
+  const regexStringBase = [...(searchWord
     .replace(/(?:es|[s]|ing)$/, ''))];
-  regexWordString = `${regexWordString
+  const regexWordString = `${regexStringBase
     .reduce((regexWord, letter, index) => {
       const isLastLetterDuplicated = getIsLastLetterDuplicated({
-        stringArray: regexWordString,
+        stringArray: regexStringBase,
         index,
         letter,
       });
       // eslint-disable-next-line max-len
       return `${regexWord}(${(diacriticCodes[letter] || letter)})${isLastLetterDuplicated ? '{0,}' : ''}`;
     }, '')}(?:es|[sx]|ing)${requirePluralAndGerundMatch}`;
+  const hardRegexWordString = searchWord.length
+    ? `${[...searchWord]
+      .reduce((regexWord, letter, index) => {
+        const isLastLetterDuplicated = getIsLastLetterDuplicated({
+          stringArray: regexStringBase,
+          index,
+          letter,
+        });
+        // eslint-disable-next-line max-len
+        return `${regexWord}(${(diacriticCodes[letter] || letter)})${isLastLetterDuplicated ? '{0,}' : ''}`;
+      }, '')}${requirePluralAndGerundMatch}`
+    : '';
 
   const startWordBoundary = '(\\W|^)';
   const endWordBoundary = '(\\W|$)';
@@ -37,6 +49,11 @@ export default (rawSearchWord, hardMatch = false) => {
   'i');
 
   const definitionsReg = new RegExp(`${startWordBoundary}(${regexWordString})${endWordBoundary}`, 'i');
+  const hardDefinitionsReg = new RegExp(`${startWordBoundary}(${hardRegexWordString})${endWordBoundary}`, 'i');
 
-  return { wordReg, definitionsReg };
+  return {
+    wordReg,
+    definitionsReg,
+    hardDefinitionsReg,
+  };
 };


### PR DESCRIPTION
## Background
The `sortByDocs` function is updated that it now sorts words based on the position in which the `searchWord` appears in the word's first definition.