### PR TITLE
feat: allow for stems and relatedTerms to be resolved

### DIFF
--- a/migrations/20230118013604-convert-stems-to-object-id.js
+++ b/migrations/20230118013604-convert-stems-to-object-id.js
@@ -1,0 +1,73 @@
+const stemsToObjectIdMigrationPipeline = [
+  {
+    $match: {
+      'stems.0': {
+        $exists: true,
+      },
+    },
+  }, {
+    $addFields: {
+      stems: {
+        $map: {
+          input: '$stems',
+          in: {
+            $cond: {
+              if: { $gte: [{ $strLenCP: '$$this' }, 24] },
+              then: { $toObjectId: '$$this' },
+              else: '$$this',
+            },
+          },
+        },
+      },
+    },
+  },
+];
+
+const revertStemsToObjectIdMigrationPipeline = [
+  {
+    $match: {
+      'stems.0': {
+        $exists: true,
+      },
+    },
+  }, {
+    $addFields: {
+      stems: {
+        $map: {
+          input: '$stems',
+          in: { $toString: '$$this' },
+        },
+      },
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return Promise.all(collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(stemsToObjectIdMigrationPipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $set: { stems: wordDoc.stems } },
+        )
+      ))));
+    }));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return Promise.all(collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(revertStemsToObjectIdMigrationPipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $set: { stems: wordDoc.stems } },
+        )
+      ))));
+    }));
+  },
+};

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -45,6 +45,7 @@ export const findWordsWithMatch = async ({
   version,
   dialects,
   examples,
+  resolve,
 }) => {
   const connection = createDbConnection();
   const Word = connection.model('Word', wordSchema);
@@ -58,6 +59,24 @@ export const findWordsWithMatch = async ({
           localField: '_id',
           foreignField: 'associatedWords',
           as: 'examples',
+        });
+    }
+
+    if (resolve && version === Versions.VERSION_2) {
+      words = words
+        .lookup({
+          from: 'words',
+          localField: 'stems',
+          foreignField: '_id',
+          as: 'stems',
+        });
+
+      words = words
+        .lookup({
+          from: 'words',
+          localField: 'relatedTerms',
+          foreignField: '_id',
+          as: 'relatedTerms',
         });
     }
 

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -186,6 +186,7 @@ export const handleQueries = async ({
     strict: strictQuery,
     dialects: dialectsQuery,
     examples: examplesQuery,
+    resolve: resolveQuery,
     isStandardIgbo,
     pronunciation,
     nsibidi,
@@ -267,6 +268,7 @@ export const handleQueries = async ({
   const strict = strictQuery === 'true';
   const dialects = dialectsQuery === 'true';
   const examples = examplesQuery === 'true';
+  const resolve = resolveQuery === 'true';
   return {
     version,
     searchWord,
@@ -278,6 +280,7 @@ export const handleQueries = async ({
     strict,
     dialects,
     examples,
+    resolve,
     isUsingMainKey,
     wordFields: {
       isStandardIgbo,

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -105,6 +105,7 @@ const getWordsFromDatabase = async (req, res, next) => {
       strict,
       dialects,
       examples,
+      resolve,
       wordFields,
       isUsingMainKey,
       redisAllVerbsAndSuffixesKey,
@@ -118,6 +119,7 @@ const getWordsFromDatabase = async (req, res, next) => {
       limit,
       dialects,
       examples,
+      resolve,
     };
     let words;
     let contentLength;
@@ -220,6 +222,7 @@ export const getWord = async (req, res, next) => {
     const {
       dialects,
       examples,
+      resolve,
       version,
     } = await handleQueries(req);
 
@@ -228,6 +231,7 @@ export const getWord = async (req, res, next) => {
       version,
       dialects,
       examples,
+      resolve,
     })
       .then(async ({ words: [word] }) => {
         if (!word) {

--- a/src/dictionaries/seed.js
+++ b/src/dictionaries/seed.js
@@ -1,6 +1,7 @@
 import map from 'lodash/map';
 import flatten from 'lodash/flatten';
 import keys from 'lodash/keys';
+import omit from 'lodash/omit';
 import { createWord } from '../controllers/words';
 import dictionary from './ig-en/ig-en.json';
 import Dialects from '../shared/constants/Dialects';
@@ -18,7 +19,7 @@ const populate = async (connection) => {
       map(keys(dictionary), (key) => {
         const value = dictionary[key];
         return map(value, (term) => {
-          const word = { ...term };
+          const word = omit({ ...term }, ['stems']);
           const cleanedKey = key.replace(/\./g, '');
           word.word = key;
           word.definitions = [

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -69,7 +69,7 @@ export const wordSchema = new Schema({
   relatedTerms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
-  stems: { type: [{ type: String }], default: [] },
+  stems: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 const tensesIndexes = Object.values(Tenses).reduce((finalIndexes, tense) => ({


### PR DESCRIPTION
## Background
Allow the `resolve` query to be passed into v2 endpoints to be able to resolve first-level nested `stems` and `relatedTerms`. This PR also performs a database migration to convert all our `stems` values from strings to ObjectIds