### PR TITLE
fix: avoid overwriting content-range response header

### DIFF
--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -19,6 +19,10 @@ const IS_COMMON = 1000;
 const SIMILARITY_FACTOR = 100;
 const NO_FACTOR = 0;
 
+// Caching
+const MAX_AGE = 86400; // 1 Day
+const S_MAX_AGE = 172800; // 2 Days
+
 const generateSecondaryKey = (version) => (
   version === Versions.VERSION_1 ? 'definitions[0]' : 'definitions[0].definitions[0]'
 );
@@ -132,7 +136,10 @@ export const packageResponse = ({
   docs,
   contentLength,
 }) => {
-  res.setHeader('Content-Range', contentLength);
+  res.set({
+    'Cache-Control': `public, max-age=${MAX_AGE}, s-maxage=${S_MAX_AGE}`,
+    'Content-Range': contentLength,
+  });
   return res.send(docs);
 };
 

--- a/src/routers/routerV2.js
+++ b/src/routers/routerV2.js
@@ -8,7 +8,7 @@ import attachRedisClient from '../middleware/attachRedisClient';
 const routerV2 = express.Router();
 
 routerV2.get('/words', analytics, validateApiKey, attachRedisClient, getWords);
-routerV2.get('/words/:id', analytics, validateApiKey, validId, attachRedisClient, getWord);
+routerV2.get(' :id', analytics, validateApiKey, validId, attachRedisClient, getWord);
 
 // Redirects to V1
 routerV2.get('/examples', (_, res) => res.redirect('/api/v1/examples'));


### PR DESCRIPTION
## Background
Express `res.set` has been updated to allow for both caching and preserving the response cache range header