### PR TITLE
fix: add individual indexes for  aggregation operator

### DIFF
--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -1,5 +1,6 @@
 import compact from 'lodash/compact';
 import WordClass from '../../shared/constants/WordClass';
+import Tenses from '../../shared/constants/Tenses';
 
 const fullTextSearchQuery = ({
   keywords,
@@ -19,6 +20,7 @@ const fullTextSearchQuery = ({
             { variations: regex.wordReg },
             { 'definitions.nsibidi': text },
             { 'dialects.word': regex.wordReg },
+            ...Object.values(Tenses).map(({ value }) => ({ [`tenses.${value}`]: regex.wordReg })),
           ]),
           ...(wordClass?.length ? { 'definitions.wordClass': { $in: wordClass } } : {}),
         }],

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -72,20 +72,41 @@ export const wordSchema = new Schema({
   stems: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
 }, { toObject: toObjectPlugin, timestamps: true });
 
-const tensesIndexes = Object.values(Tenses).reduce((finalIndexes, tense) => ({
-  ...finalIndexes,
-  [`tenses.${tense.value}`]: 1,
-}), {});
-
 wordSchema.index({
   word: 1,
+});
+wordSchema.index({
   'definitions.definitions': 1,
+});
+wordSchema.index({
+  'definitions.wordClass': 1,
+});
+wordSchema.index({
   variations: 1,
+});
+wordSchema.index({
   'definitions.nsibidi': 1,
+});
+wordSchema.index({
   'dialects.word': 1,
-  ...tensesIndexes,
-}, {
-  name: 'Word text index',
+});
+wordSchema.index({
+  'tenses.infinitive': 1,
+});
+wordSchema.index({
+  'tenses.imperative': 1,
+});
+wordSchema.index({
+  'tenses.simplePast': 1,
+});
+wordSchema.index({
+  'tenses.simplePresent': 1,
+});
+wordSchema.index({
+  'tenses.presentContinuous': 1,
+});
+wordSchema.index({
+  'tenses.future': 1,
 });
 
 toJSONPlugin(wordSchema);


### PR DESCRIPTION
## Background
Our search query uses the `$or` operator which splits up each query piece, requiring individual indexes. This PR creates individual indexes to improve search performance