### PR TITLE
fix: separate querying database for Igbo words and English words for improved performance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install Project Dependencies
         run: |
           rm -rf ./node_modules; yarn install

--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
-      - name: Use Node.js @16
+      - name: Use Node.js @18
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
       - name: Log into Docker Account
         run: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         mongodb-version: [4.0, 4.2]
       
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js v16
+      - name: Use Node.js v18
         uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Install Node.js dependencies
         run: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,16 +16,12 @@ jobs:
       with:
         fetch-depth: 0
         persist-credentials: false
-    - name: Use Node.js v16
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16
-    - name: Install Dependencies
-      run: yarn install
     - name: Use Node.js v18
       uses: actions/setup-node@v1
       with:
         node-version: 18
+    - name: Install Dependencies
+      run: yarn install
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_ACCESS_TOKEN }}

--- a/__tests__/api-mongo.test.js
+++ b/__tests__/api-mongo.test.js
@@ -377,7 +377,7 @@ describe('MongoDB Words', () => {
       const keyword = 'mili';
       const res = await getWords({ keyword });
       expect(res.status).toEqual(200);
-      expect(res.body).toHaveLength(3);
+      expect(res.body).toHaveLength(2);
       expect(uniqBy(res.body, (word) => word.id).length).toEqual(res.body.length);
       forEach(res.body, (word) => {
         WORD_KEYS_V1.forEach((key) => {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "npm-run-all -p -r start:database jest"
   },
   "engines": {
-    "node": "16",
+    "node": "18",
     "npm": "8",
     "yarn": "1.22.x"
   },

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -1,37 +1,122 @@
 import compact from 'lodash/compact';
+import { cjkRange } from '../../shared/constants/diacriticCodes';
 import WordClass from '../../shared/constants/WordClass';
 import Tenses from '../../shared/constants/Tenses';
+
+const generateMultipleNsibidi = (keywords) => (
+  keywords.map(({ text }) => (
+    { 'definitions.nsibidi': text }
+  ))
+);
+
+const generateMultipleWordRegex = (keywords) => {
+  const wordRegexes = keywords.reduce((wordRegex, { regex }, index) => {
+    if (!index) {
+      return regex.wordReg.source;
+    }
+    return `${wordRegex}|${regex.wordReg.source}`;
+  }, '');
+  const regex = new RegExp(wordRegexes, 'i');
+  return { word: { $regex: regex.source } };
+};
+
+const generateMultipleDefinitionsRegex = (keywords) => (
+  { 'definitions.definitions': { $in: keywords.map(({ regex }) => regex.definitionsReg) } }
+);
+
+const generateMultipleVariationsRegex = (keywords) => {
+  const variationsRegexes = keywords.reduce((wordRegex, { regex }, index) => {
+    if (!index) {
+      return regex.wordReg.source;
+    }
+    return `${wordRegex}|${regex.wordReg.source}`;
+  }, '');
+  const regex = new RegExp(variationsRegexes, 'i');
+  return { variations: { $regex: regex.source } };
+};
+
+const generateMultipleDialectsWordRegex = (keywords) => {
+  const dialectsWordRegex = keywords.reduce((wordRegex, { regex }, index) => {
+    if (!index) {
+      return regex.wordReg.source;
+    }
+    return `${wordRegex}|${regex.wordReg.source}`;
+  }, '');
+  const regex = new RegExp(dialectsWordRegex, 'i');
+  return { 'dialects.word': { $regex: regex.source } };
+};
+
+const generateMultipleTensesWordRegex = (keywords) => {
+  const tenses = Object.values(Tenses).map(({ value }) => {
+    const tenseRegexes = keywords.reduce((wordRegex, { regex }, index) => {
+      if (!index) {
+        return regex.wordReg.source;
+      }
+      return `${wordRegex}|${regex.wordReg.source}`;
+    }, '');
+    const regex = new RegExp(tenseRegexes, 'i');
+    return { [`tenses.${value}`]: { $regex: regex.source } };
+  });
+  return tenses;
+};
+
+const generateMultipleWordClass = (keywords) => {
+  const inWordClass = (keywords.map(({ wordClass = [] }) => wordClass) || []).flat();
+  return !inWordClass.length ? null : { 'definitions.wordClass': { $in: inWordClass } };
+};
 
 const fullTextSearchQuery = ({
   keywords,
   isUsingMainKey,
   filteringParams,
-}) => (isUsingMainKey && !keywords?.length
-  ? { word: { $regex: /./ }, ...filteringParams }
-  : (!isUsingMainKey && !keywords?.length)
+}) => {
+  const hasNsibidi = keywords.some(({ text }) => text.match(new RegExp(cjkRange)));
+  return (
+    isUsingMainKey && !keywords?.length
+      ? { word: { $regex: /./ }, ...filteringParams }
+      : (!isUsingMainKey && !keywords?.length)
+        ? { _id: { $exists: false }, id: { $exists: false } }
+        : hasNsibidi
+          ? { $or: generateMultipleNsibidi(keywords) }
+          : {
+            $and: [{
+              $or: compact([
+                generateMultipleWordRegex(keywords),
+                generateMultipleVariationsRegex(keywords),
+                generateMultipleDialectsWordRegex(keywords),
+                ...generateMultipleTensesWordRegex(keywords),
+                generateMultipleWordClass(keywords),
+              ]),
+            }],
+            ...filteringParams,
+          }
+  );
+};
+const fullTextDefinitionsSearchQuery = ({
+  keywords,
+  isUsingMainKey,
+  searchWord,
+  filteringParams,
+}) => (
+  !isUsingMainKey && !keywords?.length
     ? { _id: { $exists: false }, id: { $exists: false } }
-    : {
-      $or: keywords.map(({ text, regex, wordClass = [] }) => ({
-        $and: [{
-          $or: compact([
-            { word: text },
-            { word: { $regex: regex.wordReg } },
-            (regex.definitionsReg ? { 'definitions.definitions': { $regex: regex.definitionsReg } } : null),
-            { variations: regex.wordReg },
-            { 'definitions.nsibidi': text },
-            { 'dialects.word': regex.wordReg },
-            ...Object.values(Tenses).map(({ value }) => ({ [`tenses.${value}`]: regex.wordReg })),
-          ]),
-          ...(wordClass?.length ? { 'definitions.wordClass': { $in: wordClass } } : {}),
-        }],
-      })),
-      ...filteringParams,
-    }
+    : !keywords?.length
+      ? {}
+      : {
+        $and: [
+          { $text: { $search: searchWord } },
+          generateMultipleDefinitionsRegex(keywords),
+          filteringParams,
+        ],
+      }
 );
 
-const definitionsQuery = ({ regex, filteringParams }) => ({
-  'definitions.definitions': { $in: [regex.definitionsReg] },
-  ...filteringParams,
+const definitionsQuery = ({ regex, searchWord, filteringParams }) => ({
+  $and: [
+    { $text: { $search: searchWord } },
+    { 'definitions.definitions': { $in: [regex.definitionsReg] } },
+    filteringParams,
+  ],
 });
 
 /* Regex match query used to later to defined the Content-Range response header */
@@ -39,6 +124,7 @@ export const searchExamplesRegexQuery = (regex) => (
   { $or: [{ igbo: regex.wordReg }, { english: regex.definitionsReg }] }
 );
 export const searchIgboTextSearch = fullTextSearchQuery;
+export const searchDefinitionsWithinIgboTextSearch = fullTextDefinitionsSearchQuery;
 /* Since the word field is not non-accented yet,
  * a strict regex search for words has to be used as a workaround */
 export const strictSearchIgboQuery = (keywords) => ({

--- a/src/controllers/utils/searchWordUsingEnglish.js
+++ b/src/controllers/utils/searchWordUsingEnglish.js
@@ -1,0 +1,26 @@
+import Versions from '../../shared/constants/Versions';
+import { findWordsWithMatch } from './buildDocs';
+import { sortDocsBy } from '.';
+import { searchEnglishRegexQuery } from './queries';
+
+/* Searches for word with English stored in MongoDB */
+const searchWordUsingEnglish = async ({
+  searchWord,
+  filteringParams,
+  version,
+  regex,
+  skip,
+  limit,
+  ...rest
+}) => {
+  const query = searchEnglishRegexQuery({ regex, searchWord, filteringParams });
+  console.time(`Searching English words for ${searchWord}`);
+  const { words, contentLength } = await findWordsWithMatch({ match: query, version, ...rest });
+  const sortKey = version === Versions.VERSION_1 ? 'definitions[0]' : 'definitions[0].definitions[0]';
+  let sortedWords = sortDocsBy(searchWord, words, sortKey, version, regex);
+  sortedWords = sortedWords.slice(skip, skip + limit);
+  console.timeEnd(`Searching English words for ${searchWord}`);
+  return { words: sortedWords, contentLength };
+};
+
+export default searchWordUsingEnglish;

--- a/src/controllers/utils/searchWordUsingIgbo.js
+++ b/src/controllers/utils/searchWordUsingIgbo.js
@@ -1,0 +1,55 @@
+import compact from 'lodash/compact';
+import { searchIgboTextSearch, strictSearchIgboQuery, searchDefinitionsWithinIgboTextSearch } from './queries';
+import { findWordsWithMatch } from './buildDocs';
+import { sortDocsBy } from '.';
+
+/* Searches for a word with Igbo stored in MongoDB */
+const searchWordUsingIgbo = async ({
+  keywords,
+  strict,
+  isUsingMainKey,
+  filteringParams,
+  searchWord,
+  version,
+  regex,
+  skip,
+  limit,
+  ...rest
+}) => {
+  const allSearchKeywords = !keywords.find(({ text }) => text === searchWord)
+    ? compact(keywords.concat(searchWord
+      ? { text: searchWord, wordClass: [], regex }
+      : null),
+    )
+    : keywords;
+  const regularSearchIgboQuery = searchIgboTextSearch({
+    keywords: allSearchKeywords,
+    isUsingMainKey,
+    filteringParams,
+  });
+  const igboQuery = !strict
+    ? regularSearchIgboQuery
+    : strictSearchIgboQuery(
+      allSearchKeywords,
+    );
+  const definitionsWithinIgboQuery = searchDefinitionsWithinIgboTextSearch({
+    keywords: allSearchKeywords,
+    isUsingMainKey,
+    searchWord,
+    filteringParams,
+  });
+  console.time(`Searching Igbo words for ${searchWord}`);
+  const [igboResults, englishResults] = await Promise.all([
+    await findWordsWithMatch({ match: igboQuery, version, ...rest }),
+    await findWordsWithMatch({ match: definitionsWithinIgboQuery, version, ...rest }),
+  ]);
+  const words = igboResults.words.concat(englishResults.words);
+  const contentLength = parseInt(igboResults.contentLength, 10) + parseInt(englishResults.contentLength, 10);
+
+  let sortedWords = sortDocsBy(searchWord, words, 'word', version, regex);
+  sortedWords = sortedWords.slice(skip, skip + limit);
+  console.timeEnd(`Searching Igbo words for ${searchWord}`);
+  return { words: sortedWords, contentLength };
+};
+
+export default searchWordUsingIgbo;

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -1,5 +1,4 @@
 import map from 'lodash/map';
-import compact from 'lodash/compact';
 import mongoose from 'mongoose';
 import removePrefix from '../shared/utils/removePrefix';
 import { findSearchWord } from '../services/words';
@@ -7,11 +6,11 @@ import { NO_PROVIDED_TERM } from '../shared/constants/errorMessages';
 import { getDocumentsIds } from '../shared/utils/documentUtils';
 import createRegExp from '../shared/utils/createRegExp';
 import { REDIS_CACHE_EXPIRATION } from '../config';
-import { sortDocsBy, packageResponse, handleQueries } from './utils';
-import { searchIgboTextSearch, strictSearchIgboQuery, searchEnglishRegexQuery } from './utils/queries';
+import { packageResponse, handleQueries } from './utils';
 import { findWordsWithMatch } from './utils/buildDocs';
+import searchWordUsingEnglish from './utils/searchWordUsingEnglish';
+import searchWordUsingIgbo from './utils/searchWordUsingIgbo';
 import { createExample } from './examples';
-import Versions from '../shared/constants/Versions';
 import { wordSchema } from '../models/Word';
 
 /* Gets words from JSON dictionary */
@@ -29,76 +28,9 @@ export const getWordData = (req, res, next) => {
   }
 };
 
-/* Searches for a word with Igbo stored in MongoDB */
-export const searchWordUsingIgbo = async ({
-  query,
-  searchWord,
-  version,
-  regex,
-  skip,
-  limit,
-  ...rest
-}) => {
-  console.time(`Searching Igbo words for ${searchWord}`);
-  const { words, contentLength } = await findWordsWithMatch({ match: query, version, ...rest });
-  let sortedWords = sortDocsBy(searchWord, words, 'word', version, regex);
-  sortedWords = sortedWords.slice(skip, skip + limit);
-  console.timeEnd(`Searching Igbo words for ${searchWord}`);
-  return { words: sortedWords, contentLength };
-};
-
-/* Searches for word with English stored in MongoDB */
-export const searchWordUsingEnglish = async ({
-  query,
-  searchWord,
-  version,
-  regex,
-  skip,
-  limit,
-  ...rest
-}) => {
-  console.time(`Searching English words for ${searchWord}`);
-  const { words, contentLength } = await findWordsWithMatch({ match: query, version, ...rest });
-  const sortKey = version === Versions.VERSION_1 ? 'definitions[0]' : 'definitions[0].definitions[0]';
-  let sortedWords = sortDocsBy(searchWord, words, sortKey, version, regex);
-  sortedWords = sortedWords.slice(skip, skip + limit);
-  console.timeEnd(`Searching English words for ${searchWord}`);
-  return { words: sortedWords, contentLength };
-};
-
-/* Creates an object containing truthy key/value pairs for looking up words */
-const generateFilteringParams = (filteringParams) => (
-  Object.entries(filteringParams).reduce((finalRequiredAttributes, [key, value]) => {
-    if (key === 'isStandardIgbo' && value) {
-      return {
-        ...finalRequiredAttributes,
-        [`attributes.${key}`]: { $eq: true },
-      };
-    }
-    if (key === 'nsibidi' && value) {
-      return {
-        ...finalRequiredAttributes,
-        [`definitions.${key}`]: { $ne: '' },
-      };
-    }
-    if (key === 'pronunciation' && value) {
-      return {
-        ...finalRequiredAttributes,
-        pronunciation: { $exists: true },
-        $expr: { $gt: [{ $strLenCP: '$pronunciation' }, 10] },
-      };
-    }
-    return finalRequiredAttributes;
-  }, {})
-);
-
 /* Reuseable base controller function for getting words */
 const getWordsFromDatabase = async (req, res, next) => {
   try {
-    const hasQuotes = req.query.keyword && (req.query.keyword.match(/["'].*["']/) !== null);
-    if (hasQuotes) {
-      req.query.keyword = req.query.keyword.replace(/["']/g, '');
-    }
     const {
       version,
       searchWord,
@@ -110,7 +42,8 @@ const getWordsFromDatabase = async (req, res, next) => {
       dialects,
       examples,
       resolve,
-      wordFields,
+      hasQuotes,
+      filteringParams,
       isUsingMainKey,
       redisAllVerbsAndSuffixesKey,
       allVerbsAndSuffixes,
@@ -126,8 +59,6 @@ const getWordsFromDatabase = async (req, res, next) => {
     };
     let words;
     let contentLength;
-    let query;
-    const filteringParams = generateFilteringParams(wordFields);
     if (hasQuotes) {
       const redisWordsCacheKey = `"${searchWord}"-${skip}-${limit}-${version}-${dialects}-${resolve}-${examples}`;
       const rawCachedWords = await redisClient.get(redisWordsCacheKey);
@@ -136,9 +67,8 @@ const getWordsFromDatabase = async (req, res, next) => {
         words = cachedWords.words;
         contentLength = cachedWords.contentLength;
       } else {
-        query = searchEnglishRegexQuery({ regex, filteringParams });
         const wordsByEnglish = await searchWordUsingEnglish({
-          query,
+          filteringParams,
           version,
           regex,
           ...searchQueries,
@@ -158,20 +88,7 @@ const getWordsFromDatabase = async (req, res, next) => {
     } else {
       const parsedSegments = [...searchWord.split(' ')];
       parsedSegments.shift();
-      const allSearchKeywords = compact(keywords.concat(searchWord
-        ? { text: searchWord, wordClass: [], regex }
-        : null),
-      );
-      const regularSearchIgboQuery = searchIgboTextSearch({
-        keywords: allSearchKeywords,
-        isUsingMainKey,
-        filteringParams,
-      });
-      query = !strict
-        ? regularSearchIgboQuery
-        : strictSearchIgboQuery(
-          allSearchKeywords,
-        );
+
       const redisWordsCacheKey = `${searchWord}-${skip}-${limit}-${version}-${dialects}-${resolve}-${examples}`;
       const rawCachedWords = await redisClient.get(redisWordsCacheKey);
       const cachedWords = typeof rawCachedWords === 'string' ? JSON.parse(rawCachedWords) : rawCachedWords;
@@ -180,9 +97,12 @@ const getWordsFromDatabase = async (req, res, next) => {
         contentLength = cachedWords.contentLength;
       } else {
         const wordsByIgbo = await searchWordUsingIgbo({
-          query,
+          keywords,
           version,
           regex,
+          strict,
+          isUsingMainKey,
+          filteringParams,
           ...searchQueries,
         });
         words = wordsByIgbo.words;

--- a/src/models/Word.js
+++ b/src/models/Word.js
@@ -14,7 +14,6 @@ const definitionSchema = new Schema({
     type: String,
     default: WordClass.NNC.value,
     enum: Object.values(WordClass).map(({ value }) => value),
-    index: true,
   },
   definitions: { type: [{ type: String }], default: [] },
   nsibidi: { type: String, default: '' },
@@ -22,7 +21,7 @@ const definitionSchema = new Schema({
 }, { _id: true });
 
 const dialectSchema = new Schema({
-  word: { type: String, required: true, index: true },
+  word: { type: String, required: true },
   variations: { type: [{ type: String }], default: [] },
   dialects: { type: [{ type: String }], validate: (v) => every(v, (dialect) => Dialects[dialect].value), default: [] },
   pronunciation: { type: String, default: '' },
@@ -76,7 +75,7 @@ wordSchema.index({
   word: 1,
 });
 wordSchema.index({
-  'definitions.definitions': 1,
+  'definitions.definitions': 'text',
 });
 wordSchema.index({
   'definitions.wordClass': 1,

--- a/src/shared/constants/diacriticCodes.js
+++ b/src/shared/constants/diacriticCodes.js
@@ -43,6 +43,7 @@ export const GRAVE_LOWERCASE_U = 249;       // \u00f9
 export const GRAVE_ACUTE_LOWERCASE_U = 250; // \u00fa
 export const MACRON_LOWERCASE_U = 363;      // \u016b
 
+export const cjkRange = '[\u4E00-\u9FFF]';
 const caseInsensitiveN = `${'[n\u1e44\u01f9\u0144N\u1e45\u01f8\u0143'
   .normalize('NFD')}${'\u1e44\u01f9\u0144\u1e45\u01f8\u0143]'
   .normalize('NFC')}+[\u00B4\u0301\u0060\u00AF\u0304\u0323\u0300]{0,}`;


### PR DESCRIPTION
## Background
The ratio of scanned documents to requests was 10,000 which is way too high and would lead to massive performance hits to the API. This was such a big performance hit that MongoDB actually started firing triggered alerts within Atlas warning us about the high memory usage. This PR addresses this performance bottleneck breaking up our database queries.

### Solution
Individual indexes have been created for fields within the `Word` schema so MongoDB can pick and choose which index it needs to perform the most optimal search. Additionally, the `definitions.definitions` field now uses a text index so that it can find matching Word documents when using English even faster than before.

When a user searches for a word, two separate database queries are started at the same time so that there are two smaller requests getting handled in parallel. This means, in theory, we are calculating the same amount of documents but in half the time. But in reality, we're actually visiting way fewer documents than before.

The two separate search queries are now:
1. Search for words only with `definitions.definitions`
2. Search for words only using `word` `dialects.word` `variations` and `tenses.*`

The results that come back from these queries are combined and then finally sorted before heading back to the client.

The average number of documents scanned for the first query is under 50, while the average number of scanned documents for the second query is under 3,500. These numbers are way better than what we were doing before where we would visit more than 11,000 documents while performing a query search.

### Upgrading Node to version 18
This PR also bumps the Node version from 16 to 18.