### PR TITLE
chore: fix dockerize actions file and log aggregation pipeline for words

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 WORKDIR /app
 

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -49,6 +49,7 @@ export const findWordsWithMatch = async ({
 }) => {
   const connection = createDbConnection();
   const Word = connection.model('Word', wordSchema);
+  console.time('Aggregation completion time');
   try {
     let words = generateAggregationBase(Word, match);
 
@@ -122,9 +123,11 @@ export const findWordsWithMatch = async ({
       }
     });
 
+    console.timeEnd('Aggregation completion time');
     await handleCloseConnection(connection);
     return { words: finalWords, contentLength };
   } catch (err) {
+    console.timeEnd('Aggregation completion time');
     await handleCloseConnection(connection);
     throw err;
   }


### PR DESCRIPTION
## Background
Adds log to get better insight in how long it takes for documents to be retrieved from MongoDB alongside fixing the Dockerize GitHub Actions workflow by using Node v18 instead of v16