### PR TITLE
fix: caches lean versions of verbs and suffixes to increase caching performance

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   displayName: 'igbo-api-admin',
   testMatch: ['**/__tests__/*.js'],
-  testTimeout: 25000,
+  testTimeout: 15000,
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'js', 'json'],
   globalSetup: './testSetup.js',

--- a/src/APIs/FlagsAPI.js
+++ b/src/APIs/FlagsAPI.js
@@ -2,11 +2,11 @@ import assign from 'lodash/assign';
 import omit from 'lodash/omit';
 
 /* FlagsAPI cleans returned MongoDB data to match client-provided flags */
-export const handleWordFlags = async ({
+export const handleWordFlags = ({
   data: { words, contentLength },
   flags: { examples, dialects, resolve },
 }) => {
-  const updatedWords = await Promise.all(words.map(async (word) => {
+  const updatedWords = words.map((word) => {
     let updatedWord = assign(word);
     if (!examples) {
       updatedWord = omit(updatedWord, ['examples']);
@@ -23,6 +23,6 @@ export const handleWordFlags = async ({
       }
     }
     return updatedWord;
-  }));
+  });
   return { words: updatedWords, contentLength };
 };

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -173,6 +173,7 @@ const searchAllVerbsAndSuffixes = async ({
   const { words, contentLength } = await findWordsWithMatch({
     match: query,
     version,
+    lean: true,
   });
   return { words, contentLength };
 };

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -108,7 +108,7 @@ export const getWord = async (req, res, next) => {
         if (!data.words[0]) {
           throw new Error('No word exists with the provided id.');
         }
-        const { words } = await handleWordFlags({ data, flags });
+        const { words } = handleWordFlags({ data, flags });
         const minimizedWords = minimizeWords(words, version);
         return minimizedWords[0];
       });


### PR DESCRIPTION
## Background
This PR caches a leaner version of all verbs and suffixes that doesn't require resolving `examples`, `relatedTerms`, and `stems`