### PR TITLE
fix: remove word class portion of query to expand search

### DIFF
--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -60,11 +60,6 @@ const generateMultipleTensesWordRegex = (keywords) => {
   return tenses;
 };
 
-const generateMultipleWordClass = (keywords) => {
-  const inWordClass = (keywords.map(({ wordClass = [] }) => wordClass) || []).flat();
-  return !inWordClass.length ? {} : { 'definitions.wordClass': { $in: inWordClass } };
-};
-
 const fullTextSearchQuery = ({
   keywords,
   isUsingMainKey,
@@ -86,7 +81,6 @@ const fullTextSearchQuery = ({
                 generateMultipleDialectsWordRegex(keywords),
                 ...generateMultipleTensesWordRegex(keywords),
               ]),
-              ...generateMultipleWordClass(keywords),
             }],
             ...filteringParams,
           }


### PR DESCRIPTION
## Background
Removed the `generateMultipleWordClass` portion of the word search query to expand the flexibility of search results.