### PR TITLE
Io/migrate away from medial

### DIFF
--- a/__tests__/api-mongo.test.js
+++ b/__tests__/api-mongo.test.js
@@ -27,6 +27,7 @@ import {
 import { expectUniqSetsOfResponses } from './shared/utils';
 import createRegExp from '../src/shared/utils/createRegExp';
 import { createDbConnection, handleCloseConnection } from '../src/services/database';
+import Tenses from '../src/shared/constants/Tenses';
 
 const { ObjectId } = mongoose.Types;
 
@@ -607,6 +608,20 @@ describe('MongoDB Words', () => {
       expect(noRes.status).toEqual(200);
       expect(noRes.body).toHaveLength(0);
     });
+
+    it('should return all tenses', async () => {
+      const keyword = 'bịa';
+      const res = await getWords({ keyword });
+      expect(res.status).toEqual(200);
+      expect(res.body.length).toBeGreaterThanOrEqual(1);
+      forEach(res.body, (word) => {
+        if (word.definitions[0].wordClass === WordClass.AV.value) {
+          expect(word.tenses[Tenses.PRESENT_PASSIVE.value]).not.toBe(undefined);
+        } else if (word.definitions[0].wordClass === WordClass.PV.value) {
+          expect(word.tenses[Tenses.PRESENT_PASSIVE.value]).not.toBe(undefined);
+        }
+      });
+    });
   });
 
   describe('/GET mongodb words V2', () => {
@@ -650,6 +665,13 @@ describe('MongoDB Words', () => {
       expect(res.status).toEqual(200);
       const gbaWord = res.body.data.find(({ word }) => word === 'gba');
       expect(gbaWord).toBeTruthy();
+    });
+    it('should noun with broken portions or word', async () => {
+      const keyword = 'ọrụ';
+      const res = await getWordsV2({ keyword });
+      const ọrụWord = res.body.data.find(({ word }) => word === 'ọrụ');
+      expect(res.status).toEqual(200);
+      expect(ọrụWord).toBeTruthy();
     });
   });
 });

--- a/migrations/20230201191800-convert-medial-to-active.js
+++ b/migrations/20230201191800-convert-medial-to-active.js
@@ -1,0 +1,27 @@
+const medialToActivePipeline = [
+  {
+    $match: {
+      'definitions.0.wordClass': 'MV',
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return Promise.all(collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(medialToActivePipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $set: { 'definitions.0.wordClass': 'AV' } },
+        )
+      ))));
+    }));
+  },
+
+  async down() {
+    return null;
+  },
+};

--- a/migrations/20230201193438-add-present-passive-to-verbs.js
+++ b/migrations/20230201193438-add-present-passive-to-verbs.js
@@ -1,0 +1,53 @@
+const medialToActivePipeline = [
+  {
+    $match: {
+      $or: [
+        { 'definitions.0.wordClass': 'AV' },
+        { 'definitions.0.wordClass': 'PV' },
+        { 'definitions.0.wordClass': 'MV' },
+      ],
+    },
+  },
+];
+
+const revertMedialToActivePipeline = [
+  {
+    $match: {
+      $or: [
+        { 'definitions.0.wordClass': 'AV' },
+        { 'definitions.0.wordClass': 'PV' },
+        { 'definitions.0.wordClass': 'MV' },
+      ],
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return Promise.all(collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(medialToActivePipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $set: { 'tenses.presentPassive': '' } },
+        )
+      ))));
+    }));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    return Promise.all(collections.map(async (collection) => {
+      const rawDocs = await db.collection(collection).aggregate(revertMedialToActivePipeline);
+      const wordDocs = await rawDocs.toArray();
+      await Promise.all((wordDocs.map((wordDoc) => (
+        db.collection(collection).updateOne(
+          { _id: wordDoc._id },
+          { $unset: { 'tenses.presentPassive': null } },
+        )
+      ))));
+    }));
+  },
+};

--- a/src/controllers/utils/expandNoun.js
+++ b/src/controllers/utils/expandNoun.js
@@ -21,7 +21,6 @@ const nominalPrefixes = [
 const isRootVerb = (root, wordData) => wordData.verbs.find(({ word: headword, definitions = [] }) => (
   definitions.find(({ wordClass: nestedWordClass }) => (
     nestedWordClass === WordClass.AV.value
-    || nestedWordClass === WordClass.MV.value
     || nestedWordClass === WordClass.PV.value
   )))
   && (
@@ -48,7 +47,7 @@ const helper = (word, wordData, firstPointer, secondPointer, topSolution, meta) 
           type: PartTypes.VERB_ROOT,
           text: currentRange,
           wordInfo: isRootVerb(currentRange, wordData),
-          wordClass: [WordClass.AV.value, WordClass.MV.value, WordClass.PV.value],
+          wordClass: [WordClass.AV.value, WordClass.PV.value],
         });
         updatedMeta.isPreviousVerb = true;
         solutions.push(helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta));
@@ -78,7 +77,6 @@ export default (rawWord, wordData) => {
   const verbs = allWords.filter(({ definitions = [] }) => (
     definitions.find(({ wordClass: nestedWordClass }) => (
       nestedWordClass === WordClass.AV.value
-      || nestedWordClass === WordClass.MV.value
       || nestedWordClass === WordClass.PV.value),
     )));
   console.time('Expand noun time');

--- a/src/controllers/utils/expandVerb.js
+++ b/src/controllers/utils/expandVerb.js
@@ -97,7 +97,6 @@ const hasBeenAndStill = [
 const isRootVerb = (root, wordData) => wordData.verbs.find(({ word: headword, definitions = [] }) => (
   definitions.find(({ wordClass: nestedWordClass }) => (
     nestedWordClass === WordClass.AV.value
-    || nestedWordClass === WordClass.MV.value
     || nestedWordClass === WordClass.PV.value
   )))
   && (
@@ -144,7 +143,7 @@ const helper = (word, wordData, firstPointer, secondPointer, topSolution, meta) 
           type: PartTypes.VERB_ROOT,
           text: currentRange,
           wordInfo: isRootVerb(currentRange, wordData),
-          wordClass: [WordClass.AV.value, WordClass.MV.value, WordClass.PV.value],
+          wordClass: [WordClass.AV.value, WordClass.PV.value],
         });
         updatedMeta.isPreviousVerb = true;
         solutions.push(helper(word, wordData, secondPointer, secondPointer + 1, solution, updatedMeta));
@@ -308,7 +307,6 @@ export default (rawWord, wordData) => {
   const verbs = allWords.filter(({ definitions = [] }) => (
     definitions.find(({ wordClass: nestedWordClass }) => (
       nestedWordClass === WordClass.AV.value
-      || nestedWordClass === WordClass.MV.value
       || nestedWordClass === WordClass.PV.value),
     )));
   const wordSuffixes = allWords.filter(({ definitions = [] }) => (

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -132,7 +132,6 @@ export const searchForAllVerbsAndSuffixesQuery = () => ({
   'definitions.wordClass': {
     $in: [
       WordClass.AV.value,
-      WordClass.MV.value,
       WordClass.PV.value,
       WordClass.ISUF.value,
       WordClass.ESUF.value,

--- a/src/shared/constants/Tenses.js
+++ b/src/shared/constants/Tenses.js
@@ -11,6 +11,10 @@ export default {
     value: 'simplePast',
     label: 'Simple Past',
   },
+  PRESENT_PASSIVE: {
+    value: 'presentPassive',
+    label: 'Present Passive',
+  },
   SIMPLE_PRESENT: {
     value: 'simplePresent',
     label: 'Simple Present',

--- a/src/shared/constants/WordClass.js
+++ b/src/shared/constants/WordClass.js
@@ -11,10 +11,6 @@ export default {
     value: 'AV',
     label: 'Active verb',
   },
-  MV: {
-    value: 'MV',
-    label: 'Medial verb',
-  },
   PV: {
     value: 'PV',
     label: 'Passive verb',

--- a/src/shared/utils/createRegExp.js
+++ b/src/shared/utils/createRegExp.js
@@ -1,3 +1,4 @@
+import last from 'lodash/last';
 import removeAccents from './removeAccents';
 import diacriticCodes from '../constants/diacriticCodes';
 
@@ -27,7 +28,7 @@ export default (rawSearchWord, hardMatch = false) => {
       // eslint-disable-next-line max-len
       return `${regexWord}(${(diacriticCodes[letter] || letter)})${isLastLetterDuplicated ? '{0,}' : ''}`;
     }, '')}(?:es|[sx]|ing)${requirePluralAndGerundMatch}`;
-  const hardRegexWordString = searchWord.length
+  let hardRegexWordString = searchWord.length
     ? `${[...searchWord]
       .reduce((regexWord, letter, index) => {
         const isLastLetterDuplicated = getIsLastLetterDuplicated({
@@ -39,6 +40,11 @@ export default (rawSearchWord, hardMatch = false) => {
         return `${regexWord}(${(diacriticCodes[letter] || letter)})${isLastLetterDuplicated ? '{0,}' : ''}`;
       }, '')}${requirePluralAndGerundMatch}`
     : '';
+  const hardRegexWordStringPieces = [...hardRegexWordString];
+  if (last(hardRegexWordStringPieces) === '?') {
+    hardRegexWordStringPieces.pop();
+  }
+  hardRegexWordString = hardRegexWordStringPieces.join('');
 
   const startWordBoundary = '(\\W|^)';
   const endWordBoundary = '(\\W|$)';


### PR DESCRIPTION
## Background
This PR converts all our medial verbs into active verbs and creates a new `tenses.presentPassive` field as another verb conjugation option. Additionally, the sorting order for words was slightly off. For example, the word ọrụ wouldn't appear as the first result despite a user typing in the word with its correct spelling. That bug was addressed within this PR by updating the string similarity logic alongside updating the `hardDefinitionRegex` value so that it's more strict while matching search words within English definitions.