### PR TITLE
feat(tags): support filtering by `tags` in v2

### DIFF
--- a/__tests__/shared/constants.js
+++ b/__tests__/shared/constants.js
@@ -34,6 +34,7 @@ export const WORD_KEYS_V2 = [
   'hypernyms',
   'hyponyms',
   'attributes',
+  'tags',
 ];
 export const EXAMPLE_KEYS_V1 = [
   'igbo',

--- a/src/APIs/FlagsAPI.js
+++ b/src/APIs/FlagsAPI.js
@@ -5,12 +5,7 @@ import omit from 'lodash/omit';
 /* FlagsAPI cleans returned MongoDB data to match client-provided flags */
 export const handleWordFlags = ({
   data: { words, contentLength },
-  flags: {
-    examples,
-    dialects,
-    resolve,
-    tags,
-  },
+  flags: { examples, dialects, resolve },
 }) => {
   const updatedWords = compact(words.map((word) => {
     let updatedWord = assign(word);
@@ -28,6 +23,17 @@ export const handleWordFlags = ({
         updatedWord.relatedTerms = updatedWord.relatedTerms.map((relatedTerm) => relatedTerm._id || relatedTerm.id);
       }
     }
+    return updatedWord;
+  }));
+  return { words: updatedWords, contentLength };
+};
+
+export const handleTagsFlag = ({
+  data: { words },
+  flags: { tags },
+}) => {
+  const updatedWords = compact(words.map((word) => {
+    const updatedWord = assign(word);
     if (tags.length && Array.isArray(word.tags)) {
       const hasTags = word.tags.some((tag) => tags.includes(tag));
       if (!hasTags) {
@@ -36,5 +42,5 @@ export const handleWordFlags = ({
     }
     return updatedWord;
   }));
-  return { words: updatedWords, contentLength };
+  return { words: updatedWords, contentLength: updatedWords.length };
 };

--- a/src/APIs/FlagsAPI.js
+++ b/src/APIs/FlagsAPI.js
@@ -1,12 +1,18 @@
+import compact from 'lodash/compact';
 import assign from 'lodash/assign';
 import omit from 'lodash/omit';
 
 /* FlagsAPI cleans returned MongoDB data to match client-provided flags */
 export const handleWordFlags = ({
   data: { words, contentLength },
-  flags: { examples, dialects, resolve },
+  flags: {
+    examples,
+    dialects,
+    resolve,
+    tags,
+  },
 }) => {
-  const updatedWords = words.map((word) => {
+  const updatedWords = compact(words.map((word) => {
     let updatedWord = assign(word);
     if (!examples) {
       updatedWord = omit(updatedWord, ['examples']);
@@ -22,7 +28,13 @@ export const handleWordFlags = ({
         updatedWord.relatedTerms = updatedWord.relatedTerms.map((relatedTerm) => relatedTerm._id || relatedTerm.id);
       }
     }
+    if (tags.length && Array.isArray(word.tags)) {
+      const hasTags = word.tags.some((tag) => tags.includes(tag));
+      if (!hasTags) {
+        return null;
+      }
+    }
     return updatedWord;
-  });
+  }));
   return { words: updatedWords, contentLength };
 };

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -94,6 +94,7 @@ export const findWordsWithMatch = async ({
         tenses: 1,
         examples: 1,
         dialects: 1,
+        tags: 1,
       })
       .append([
         { $unset: `attributes.${WordAttributes.IS_COMPLETE.value}` },
@@ -114,6 +115,7 @@ export const findWordsWithMatch = async ({
             dialects: dialect.dialects.map((d) => Dialects[d].label),
           },
         }), {});
+        delete word.tags;
       }
     });
 

--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -248,6 +248,7 @@ export const handleQueries = async ({
     strict: strictQuery,
     dialects: dialectsQuery,
     examples: examplesQuery,
+    tags: tagsQuery,
     resolve: resolveQuery,
     isStandardIgbo,
     pronunciation,
@@ -343,6 +344,7 @@ export const handleQueries = async ({
   const strict = strictQuery === 'true';
   const dialects = dialectsQuery === 'true';
   const examples = examplesQuery === 'true';
+  const tags = tagsQuery ? tagsQuery.replaceAll(/[[\]']/g, '').split(',').map((tag) => tag.trim()) : [];
   const resolve = resolveQuery === 'true';
   const wordFields = {
     isStandardIgbo,
@@ -353,6 +355,7 @@ export const handleQueries = async ({
     dialects,
     examples,
     resolve,
+    tags,
   };
   const filteringParams = generateFilteringParams(wordFields);
   return {

--- a/src/controllers/utils/searchWordUsingEnglish.js
+++ b/src/controllers/utils/searchWordUsingEnglish.js
@@ -3,7 +3,7 @@ import { findWordsWithMatch } from './buildDocs';
 import { sortDocsBy } from '.';
 import { searchEnglishRegexQuery } from './queries';
 import { getCachedWords, setCachedWords } from '../../APIs/RedisAPI';
-import { handleWordFlags } from '../../APIs/FlagsAPI';
+import { handleWordFlags, handleTagsFlag } from '../../APIs/FlagsAPI';
 
 /* Searches for word with English stored in MongoDB */
 const searchWordUsingEnglish = async ({
@@ -39,6 +39,10 @@ const searchWordUsingEnglish = async ({
   }
 
   const sortKey = version === Versions.VERSION_1 ? 'definitions[0]' : 'definitions[0].definitions[0]';
+  responseData = handleTagsFlag({
+    data: { words: responseData.words },
+    flags,
+  });
   let sortedWords = sortDocsBy(searchWord, responseData.words, sortKey, version, regex);
   sortedWords = sortedWords.slice(skip, skip + limit);
   return handleWordFlags({

--- a/src/controllers/utils/searchWordUsingIgbo.js
+++ b/src/controllers/utils/searchWordUsingIgbo.js
@@ -3,7 +3,7 @@ import { searchIgboTextSearch, strictSearchIgboQuery, searchDefinitionsWithinIgb
 import { findWordsWithMatch } from './buildDocs';
 import { sortDocsBy } from '.';
 import { getCachedWords, setCachedWords } from '../../APIs/RedisAPI';
-import { handleWordFlags } from '../../APIs/FlagsAPI';
+import { handleTagsFlag, handleWordFlags } from '../../APIs/FlagsAPI';
 
 /* Searches for a word with Igbo stored in MongoDB */
 const searchWordUsingIgbo = async ({
@@ -69,6 +69,10 @@ const searchWordUsingIgbo = async ({
     });
   }
 
+  responseData = handleTagsFlag({
+    data: { words: responseData.words },
+    flags,
+  });
   let sortedWords = sortDocsBy(searchWord, responseData.words, 'word', version, regex);
   sortedWords = sortedWords.slice(skip, skip + limit);
   return handleWordFlags({


### PR DESCRIPTION
## Background
This PR adds support for filtering by `tags` for version 2 of the Igbo API. The expected shape of the `tags` param is a stringified array of valid [`WordTags`](https://github.com/nkowaokwu/igbo_api/blob/master/src/shared/constants/WordTags.js) values.