### PR TITLE
fix(filters): prevent word duplicates while filtering

### DIFF
--- a/src/controllers/utils/searchWordUsingIgbo.js
+++ b/src/controllers/utils/searchWordUsingIgbo.js
@@ -58,7 +58,13 @@ const searchWordUsingIgbo = async ({
       findWordsWithMatch({ match: definitionsWithinIgboQuery, version }),
     ]);
     console.timeEnd(`Searching Igbo words for ${searchWord}`);
-    const words = igboResults.words.concat(englishResults.words);
+    // Prevents from duplicate word documents from being included in the final words array
+    const words = searchWord ? igboResults.words.concat(englishResults.words).reduce((finalWords, word) => {
+      if (!finalWords.find((finalWord) => finalWord.id.equals(word.id.toString()))) {
+        finalWords.push(word);
+      }
+      return finalWords;
+    }, []) : igboResults.words;
     const contentLength = parseInt(igboResults.contentLength, 10) + parseInt(englishResults.contentLength, 10);
 
     responseData = await setCachedWords({


### PR DESCRIPTION
## Background
Duplicate word entries were getting returned when a request that had `searchWord === ''` and filters applied was made. This PR fixes this bug by first checking to see if there's a truthy value for `searchWord`. If `searchWord` is truthy, then we will concatenate both Igbo and English word results. If `searchWord` is falsey, then we will just use the Igbo word results.