### PR TITLE
fix: improve filtering performance

### DIFF
--- a/__tests__/api-mongo.test.js
+++ b/__tests__/api-mongo.test.js
@@ -537,7 +537,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return a word marked as isStandardIgbo', async () => {
+    it('should return a word that is a common noun', async () => {
       const connection = createDbConnection();
       const Word = connection.model('Word', wordSchema);
       const word = {
@@ -556,69 +556,13 @@ describe('MongoDB Words', () => {
       const validWord = new Word(word);
       await validWord.save();
       await handleCloseConnection(connection);
-      const res = await getWords({ keyword: word.word, isStandardIgbo: true });
+      const res = await getWords({ keyword: word.word, wordClasses: '[NNC]' });
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeGreaterThanOrEqual(1);
       forEach(res.body, (wordRes) => {
         expect(wordRes.attributes.isStandardIgbo).toEqual(true);
       });
-      const noRes = await getWords({ keyword: word.word, pronunciation: true });
-      expect(noRes.status).toEqual(200);
-      expect(noRes.body).toHaveLength(0);
-    });
-
-    it('should return a word marked with nsibidi', async () => {
-      const connection = createDbConnection();
-      const Word = connection.model('Word', wordSchema);
-      const word = {
-        word: 'nsibidi',
-        definitions: [{
-          wordClass: 'NNC',
-          definitions: ['first definition', 'second definition'],
-          nsibidi: 'nsibidi',
-        }],
-        dialects: [],
-        examples: [new ObjectId(), new ObjectId()],
-        stems: [],
-      };
-      const validWord = new Word(word);
-      await validWord.save();
-      await handleCloseConnection(connection);
-      const res = await getWords({ keyword: word.word, nsibidi: true });
-      expect(res.status).toEqual(200);
-      expect(res.body.length).toBeGreaterThanOrEqual(1);
-      forEach(res.body, (wordRes) => {
-        expect(wordRes.nsibidi).not.toEqual(undefined);
-      });
-      const noRes = await getWords({ keyword: word.word, isStandardIgbo: true });
-      expect(noRes.status).toEqual(200);
-      expect(noRes.body).toHaveLength(0);
-    });
-
-    it('should return a word marked with pronunciation', async () => {
-      const connection = createDbConnection();
-      const Word = connection.model('Word', wordSchema);
-      const word = {
-        word: 'pronunciation',
-        definitions: [{
-          wordClass: 'NNC',
-          definitions: ['first definition', 'second definition'],
-        }],
-        dialects: [],
-        examples: [new ObjectId(), new ObjectId()],
-        pronunciation: 'audio-pronunciation',
-        stems: [],
-      };
-      const validWord = new Word(word);
-      await validWord.save();
-      await handleCloseConnection(connection);
-      const res = await getWords({ keyword: word.word, pronunciation: true });
-      expect(res.status).toEqual(200);
-      expect(res.body.length).toBeGreaterThanOrEqual(1);
-      forEach(res.body, (wordRes) => {
-        expect(wordRes.pronunciation.length).toBeGreaterThanOrEqual(10);
-      });
-      const noRes = await getWords({ keyword: word.word, nsibidi: true });
+      const noRes = await getWords({ keyword: word.word, wordClasses: ['ADJ'] });
       expect(noRes.status).toEqual(200);
       expect(noRes.body).toHaveLength(0);
     });

--- a/src/APIs/FlagsAPI.js
+++ b/src/APIs/FlagsAPI.js
@@ -27,26 +27,3 @@ export const handleWordFlags = ({
   }));
   return { words: updatedWords, contentLength };
 };
-
-export const handleFiltering = ({
-  data: { words },
-  flags: { tags, wordClasses },
-}) => {
-  const updatedWords = compact(words.map((word) => {
-    const updatedWord = assign(word);
-    if (tags.length && Array.isArray(word.tags)) {
-      const hasTags = word.tags.some((tag) => tags.includes(tag));
-      if (!hasTags) {
-        return null;
-      }
-    }
-    if (wordClasses.length) {
-      const hasWordClass = word.definitions.some(({ wordClass }) => wordClasses.includes(wordClass));
-      if (!hasWordClass) {
-        return null;
-      }
-    }
-    return updatedWord;
-  }));
-  return { words: updatedWords, contentLength: updatedWords.length };
-};

--- a/src/controllers/utils/searchWordUsingEnglish.js
+++ b/src/controllers/utils/searchWordUsingEnglish.js
@@ -3,18 +3,18 @@ import { findWordsWithMatch } from './buildDocs';
 import { sortDocsBy } from '.';
 import { searchEnglishRegexQuery } from './queries';
 import { getCachedWords, setCachedWords } from '../../APIs/RedisAPI';
-import { handleWordFlags, handleFiltering } from '../../APIs/FlagsAPI';
+import { handleWordFlags } from '../../APIs/FlagsAPI';
 
 /* Searches for word with English stored in MongoDB */
 const searchWordUsingEnglish = async ({
   redisClient,
-  filteringParams,
   version,
   regex,
   searchWord,
   skip,
   limit,
   flags,
+  filters,
 }) => {
   let responseData = {};
   const redisWordsCacheKey = `"${searchWord}"-${version}`;
@@ -26,7 +26,7 @@ const searchWordUsingEnglish = async ({
       contentLength: cachedWords.contentLength,
     };
   } else {
-    const query = searchEnglishRegexQuery({ regex, searchWord, filteringParams });
+    const query = searchEnglishRegexQuery({ regex, searchWord, filters });
     console.time(`Searching English words for ${searchWord}`);
     const { words, contentLength } = await findWordsWithMatch({ match: query, version });
     console.timeEnd(`Searching English words for ${searchWord}`);
@@ -39,10 +39,6 @@ const searchWordUsingEnglish = async ({
   }
 
   const sortKey = version === Versions.VERSION_1 ? 'definitions[0]' : 'definitions[0].definitions[0]';
-  responseData = handleFiltering({
-    data: { words: responseData.words },
-    flags,
-  });
   let sortedWords = sortDocsBy(searchWord, responseData.words, sortKey, version, regex);
   sortedWords = sortedWords.slice(skip, skip + limit);
   return handleWordFlags({

--- a/src/controllers/words.js
+++ b/src/controllers/words.js
@@ -42,8 +42,8 @@ const getWordsFromDatabase = async (req, res, next) => {
       limit,
       strict,
       flags,
+      filters,
       hasQuotes,
-      filteringParams,
       isUsingMainKey,
       redisClient,
     } = await handleQueries(req);
@@ -52,12 +52,12 @@ const getWordsFromDatabase = async (req, res, next) => {
       skip,
       limit,
       flags,
+      filters,
     };
     let responseData = {};
     if (hasQuotes) {
       responseData = await searchWordUsingEnglish({
         redisClient,
-        filteringParams,
         version,
         regex,
         ...searchQueries,
@@ -70,7 +70,6 @@ const getWordsFromDatabase = async (req, res, next) => {
         regex,
         strict,
         isUsingMainKey,
-        filteringParams,
         ...searchQueries,
       });
     }

--- a/swagger.json
+++ b/swagger.json
@@ -186,27 +186,6 @@
             "in": "query",
             "required": false,
             "type": "boolean"
-          },
-          {
-            "name": "isStandardIgbo",
-            "description": "Returns words that are marked as Standard Igbo",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "name": "pronunciation",
-            "description": "Returns words that have audio pronunciations",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
-          },
-          {
-            "name": "nsibidi",
-            "description": "Returns words that have Nsịbịdị equivalents",
-            "in": "query",
-            "required": false,
-            "type": "boolean"
           }
         ],
         "responses": {


### PR DESCRIPTION
## Background
The filtering functionality has been incredibly slow. Load times can be as high as 30 seconds when attempting to filter without any `keyword` value.

This PR changes the MongoDB search queries so that it uses the filtering options `tags` and `wordClasses` to take advantage of the DB indexes to improve search performance.