### PR TITLE
fix(sort): rely on word similaries to improve search accuracy

### DIFF
--- a/src/controllers/utils/index.js
+++ b/src/controllers/utils/index.js
@@ -88,10 +88,10 @@ export const sortDocsBy = (searchWord, docs, key, version, regex) => (
       ? 11
       : rawNextDefinitionMatchIndex;
     const prevDefinitionMatchIndexFactor = (
-      MATCHING_DEFINITION_INDEX - prevDefinitionMatchIndexValue * MATCHING_DEFINITION_INDEX_FACTOR
+      MATCHING_DEFINITION_INDEX - (prevDefinitionMatchIndexValue * MATCHING_DEFINITION_INDEX_FACTOR)
     );
     const nextDefinitionMatchIndexFactor = (
-      MATCHING_DEFINITION_INDEX - nextDefinitionMatchIndexValue * MATCHING_DEFINITION_INDEX_FACTOR
+      MATCHING_DEFINITION_INDEX - (nextDefinitionMatchIndexValue * MATCHING_DEFINITION_INDEX_FACTOR)
     );
 
     const prevDocDifferenceWithUnderdots = stringSimilarity
@@ -115,15 +115,15 @@ export const sortDocsBy = (searchWord, docs, key, version, regex) => (
     );
 
     const prevDocSimilarityFactor = (prevDocDifferences >= SIMILAR_WORD_THRESHOLD
-      ? prevDocValueLengthDifference : 0) * SIMILARITY_FACTOR;
+      ? prevDocValueLengthDifference : 0) * SIMILARITY_FACTOR + (prevDocDifferences * SIMILARITY_FACTOR);
     const nextDocSimilarityFactor = (nextDocDifferences >= SIMILAR_WORD_THRESHOLD
-      ? nextDocValueLengthDifference : 0) * SIMILARITY_FACTOR;
+      ? nextDocValueLengthDifference : 0) * SIMILARITY_FACTOR + (nextDocDifferences * SIMILARITY_FACTOR);
 
-    const prevDocNsibidiFactor = prevDoc?.attributes?.isCommon && prevDocDifferences > 1 ? IS_COMMON : 0;
-    const nextDocNsibidiFactor = nextDoc?.attributes?.isCommon && nextDocDifferences > 1 ? IS_COMMON : 0;
+    const prevDocIsCommonFactor = prevDoc?.attributes?.isCommon && prevDocDifferences > 1 ? IS_COMMON : 0;
+    const nextDocIsCommonFactor = nextDoc?.attributes?.isCommon && nextDocDifferences > 1 ? IS_COMMON : 0;
 
-    const finalPrevDocDiff = prevDocSimilarityFactor + prevDocNsibidiFactor + prevDefinitionMatchIndexFactor;
-    const finalNextDocDiff = nextDocSimilarityFactor + nextDocNsibidiFactor + nextDefinitionMatchIndexFactor;
+    const finalPrevDocDiff = prevDocSimilarityFactor + prevDocIsCommonFactor + prevDefinitionMatchIndexFactor;
+    const finalNextDocDiff = nextDocSimilarityFactor + nextDocIsCommonFactor + nextDefinitionMatchIndexFactor;
 
     if (finalPrevDocDiff === finalNextDocDiff) {
       return NO_FACTOR;


### PR DESCRIPTION
## Background
Updates the sorting algorithm so that it will use the words similarity score generated by the `string-similarity` package. Additionally, the variables `prevDocNsibidiFactor` and `nextDocNsibidiFactor` have been renamed to `prevDocIsCommonFactor` and `nextDocIsCommonFactor` since they use the `isCommon` word attribute instead of Nsịbịdị.

## Acknowledgement
Thanks to @anukem for bringing attention to the fact that when a user searches with the keyword "maa" the first-word result is "gbu"

![image](https://user-images.githubusercontent.com/16169291/232671488-c8528186-b4a1-4af1-a52d-f697ebb99d14.png)
