### PR TITLE
feat: extend ExampleStyles to include biblical

### DIFF
--- a/src/shared/constants/ExampleStyles.js
+++ b/src/shared/constants/ExampleStyles.js
@@ -11,4 +11,8 @@ export default {
     value: 'proverb',
     label: 'Proverb',
   },
+  BIBLICAL: {
+    value: 'biblical',
+    label: 'biblical',
+  },
 };


### PR DESCRIPTION
## Background
We want to start supporting sentences from the Bible. The `ExampleStyles.js` file will be extended to support the new sentence style.