### PR TITLE
chore: introduce staging environment

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,6 @@
 {
   "projects": {
-    "default": "igbo-api-bb22d"
+    "default": "igbo-api-bb22d",
+    "staging": "igbo-api-staging-99a67"
   }
 }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         yarn install
         npm install -g firebase-tools
-        firebase use default --token $FIREBASE_TOKEN
+        firebase use staging --token $FIREBASE_TOKEN
         yarn build
     - name: Test Server Build Process
       run: yarn test:build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "start:emulators": "node_modules/.bin/firebase emulators:start --only functions,hosting",
     "start:watch": "nodemon --watch './src' --ext ts,js,tsx,jsx  --ignore './functions' --verbose --exec yarn build",
     "clean": "shx rm -rf node_modules/ dist/ out/ yarn.lock package-lock.json *.log",
-    "predev": "firebase functions:config:set runtime.env=development",
+    "predev": "firebase functions:config:set runtime.env=development && firebase use staging",
     "dev": "npm-run-all -p start:watch start:emulators start:database",
     "predev:full": "firebase functions:config:set env.redis_url=redis://localhost:6379 env.replica_set=true env.redis_status=true",
     "dev:full": "npm-run-all -p start:watch start:emulators start:database:replica",

--- a/src/pages/docs/guides/firebase.mdx
+++ b/src/pages/docs/guides/firebase.mdx
@@ -12,11 +12,13 @@ Please follow this [Firebase Getting Started Guide](https://firebase.google.com/
 
 ## Step 2: Replace the `default` Firebase Project Name
 
-Within [.firebaserc](https://github.com/nkowaokwu/igbo_api/blob/master/.firebaserc), replace the project name `igbo-api-bb22d` with your new Firebase project name
+Within [.firebaserc](https://github.com/nkowaokwu/igbo_api/blob/master/.firebaserc), replace the project name `igbo-api-bb22d` and 
+`igbo-api-staging-99a67` with your new Firebase project name
 
 ## Step 3: Replace the Firebase Config file
 
-Within [firebase.js](https://github.com/nkowaokwu/igbo_api/blob/master/src/services/firebase.js#L5-L13), replace the `FIREBASE_CONFIG` object with your firebase project config object
+Within [firebase.js](https://github.com/nkowaokwu/igbo_api/blob/master/src/services/firebase.js#L5-L13), replace the 
+`PRODUCTION_FIREBASE_CONFIG` and `STAGING_FIREBASE_CONFIG` objects with your firebase project config object
 
 ## Step 4: Merging forked changes into main repo
 

--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -2,7 +2,16 @@ import { getApp, initializeApp } from 'firebase/app';
 import { getFunctions, connectFunctionsEmulator } from 'firebase/functions';
 import { isProduction } from '../config';
 
-const FIREBASE_CONFIG = {
+const STAGING_FIREBASE_CONFIG = {
+  apiKey: 'AIzaSyBk96Lx1weQcOliPZfc3w2aw1Az8n16E8o',
+  authDomain: 'igbo-api-staging-99a67.firebaseapp.com',
+  projectId: 'igbo-api-staging-99a67',
+  storageBucket: 'igbo-api-staging-99a67.appspot.com',
+  messagingSenderId: '225886570045',
+  appId: '1:225886570045:web:06ec83640f8868f5a04c54',
+};
+
+const PRODUCTION_FIREBASE_CONFIG = {
   apiKey: 'AIzaSyBDXPLmvu7YEagwdgp_W4uoZhCglbXrG6M',
   authDomain: 'igbo-api-bb22d.firebaseapp.com',
   projectId: 'igbo-api-bb22d',
@@ -12,7 +21,7 @@ const FIREBASE_CONFIG = {
   measurementId: 'G-YGGV667F2H',
 };
 
-initializeApp(FIREBASE_CONFIG);
+initializeApp(isProduction ? PRODUCTION_FIREBASE_CONFIG : STAGING_FIREBASE_CONFIG);
 
 const functions = getFunctions(getApp());
 if (!isProduction) {


### PR DESCRIPTION
## Describe your changes
Introduces the `STAGING_FIREBASE_CONFIG` and `PRODUCTION_FIREBASE_CONFIG` objects to allow the project to switch between projects while CI/CD is running.

## Issue ticket number and link
N/A

## Motivation and Context
Whenever an integration GitHub action is running while the codebase is being deployed to production, a race condition occurs where the runtime environment is incorrectly set to `test`. 

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A
