### PR TITLE
Io/save developer API tokens

### DIFF
--- a/src/controllers/developers.js
+++ b/src/controllers/developers.js
@@ -33,12 +33,11 @@ export const postDeveloper = async (req, res, next) => {
     }
 
     const apiKey = generateApiKey();
-    const hashedApiKey = await hash(apiKey, 10);
     const hashedPassword = await hash(password, 10);
     const developer = new Developer({
       name,
       email,
-      apiKey: hashedApiKey,
+      apiKey,
       password: hashedPassword,
     });
     await developer.save();

--- a/src/middleware/validateApiKey.js
+++ b/src/middleware/validateApiKey.js
@@ -43,8 +43,22 @@ const findDeveloper = async (apiKey) => {
   console.time('Finding developer account');
   const connection = createDbConnection();
   const Developer = connection.model('Developer', developerSchema);
+  let developer = await Developer.findOne({ apiKey });
+  if (developer) {
+    console.timeEnd('Finding developer account');
+    return developer;
+  }
+  // Legacy implementation: hashed API tokens can't be indexed
+  // This logic attempts to find the developer document and update it
+  // with the API token
   const developers = await Developer.find({});
-  const developer = developers.find((dev) => compareSync(apiKey, dev.apiKey));
+  developer = developers.find((dev) => compareSync(apiKey, dev.apiKey));
+  if (developer) {
+    developer.apiKey = apiKey;
+    const updatedDeveloper = await developer.save();
+    console.timeEnd('Finding developer account');
+    return updatedDeveloper;
+  }
   console.timeEnd('Finding developer account');
   return developer;
 };

--- a/src/models/Developer.js
+++ b/src/models/Developer.js
@@ -4,7 +4,12 @@ import { toJSONPlugin, toObjectPlugin } from './plugins';
 const { Schema } = mongoose;
 export const developerSchema = new Schema({
   name: { type: String, default: '', required: true },
-  apiKey: { type: String, default: '', required: true },
+  apiKey: {
+    type: String,
+    default: '',
+    required: true,
+    index: true,
+  },
   email: { type: String, default: '', required: true },
   password: { type: String, default: '', required: true },
   usage: {


### PR DESCRIPTION
## Describe your changes
Applies an index onto the Developer `apiKey` field. Additionally, the API will first use the index to find the developer. If there is no developer returned, then it will scan the entire Developer collection. If it finds a developer, it will update the document's `apiKey` to save the API token to be able to use the index the next time.

## Issue ticket number and link
N/A

## Motivation and Context
Developers were experiencing 8+ second response times for each of their requests.

## How Has This Been Tested?
Locally on my machine with automated tests.

## Screenshots (if appropriate):
N/A
