### PR TITLE
fix: remove project icon "NG" and use default icon

### DIFF
--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -5,7 +5,6 @@ export default {
   logo: <span>Igbo API Documentation</span>,
   project: {
     link: 'https://github.com/nkowaokwu/igbo_api',
-    icon: <span>🇳🇬</span>,
   },
   useNextSeoProps() {
     return {
@@ -33,8 +32,14 @@ export default {
       <meta property="twitter:image:alt" content="Igbo API Documentation" />
 
       {/* Meta image */}
-      <meta property="og:image" content="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/igbo_api_banner.png" />
-      <meta property="twitter:image" content="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/igbo_api_banner.png" />
+      <meta
+        property="og:image"
+        content="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/igbo_api_banner.png"
+      />
+      <meta
+        property="twitter:image"
+        content="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/igbo_api_banner.png"
+      />
 
       {/* Open Graph / Facebook */}
       <meta property="og:type" content="website" />
@@ -46,16 +51,29 @@ export default {
       <meta property="twitter:url" content="https://igboapi.com/" />
 
       {/* Favicon */}
-      <link rel="apple-touch-icon" sizes="180x180" href="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/favicon/apple-touch-icon.png" />
-      <link rel="icon" type="image/png" sizes="32x32" href="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/favicon/favicon-32x32.png" />
-      <link rel="icon" type="image/png" sizes="16x16" href="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/favicon/favicon-16x16.png" />
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/favicon/apple-touch-icon.png"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        sizes="32x32"
+        href="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/favicon/favicon-32x32.png"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        sizes="16x16"
+        href="https://nkowaokwu.s3.us-west-1.amazonaws.com/assets/icons/igbo_api/favicon/favicon-16x16.png"
+      />
     </>
   ),
   footer: {
     text: (
       <span>
-        ©
-        {new Date().getFullYear()}
+        ©{new Date().getFullYear()}
         <a href="https://igboapi.com" target="_blank" rel="noreferrer">
           Igbo API
         </a>
@@ -66,6 +84,13 @@ export default {
   chat: {
     link: 'https://twitter.com/nkowaokwu',
     // eslint-disable-next-line max-len
-    icon: <svg width="24" height="24" viewBox="0 0 248 204"><path fill="currentColor" d="M221.95 51.29c.15 2.17.15 4.34.15 6.53 0 66.73-50.8 143.69-143.69 143.69v-.04c-27.44.04-54.31-7.82-77.41-22.64 3.99.48 8 .72 12.02.73 22.74.02 44.83-7.61 62.72-21.66-21.61-.41-40.56-14.5-47.18-35.07a50.338 50.338 0 0 0 22.8-.87C27.8 117.2 10.85 96.5 10.85 72.46v-.64a50.18 50.18 0 0 0 22.92 6.32C11.58 63.31 4.74 33.79 18.14 10.71a143.333 143.333 0 0 0 104.08 52.76 50.532 50.532 0 0 1 14.61-48.25c20.34-19.12 52.33-18.14 71.45 2.19 11.31-2.23 22.15-6.38 32.07-12.26a50.69 50.69 0 0 1-22.2 27.93c10.01-1.18 19.79-3.86 29-7.95a102.594 102.594 0 0 1-25.2 26.16z" /></svg>,
+    icon: (
+      <svg width="24" height="24" viewBox="0 0 248 204">
+        <path
+          fill="currentColor"
+          d="M221.95 51.29c.15 2.17.15 4.34.15 6.53 0 66.73-50.8 143.69-143.69 143.69v-.04c-27.44.04-54.31-7.82-77.41-22.64 3.99.48 8 .72 12.02.73 22.74.02 44.83-7.61 62.72-21.66-21.61-.41-40.56-14.5-47.18-35.07a50.338 50.338 0 0 0 22.8-.87C27.8 117.2 10.85 96.5 10.85 72.46v-.64a50.18 50.18 0 0 0 22.92 6.32C11.58 63.31 4.74 33.79 18.14 10.71a143.333 143.333 0 0 0 104.08 52.76 50.532 50.532 0 0 1 14.61-48.25c20.34-19.12 52.33-18.14 71.45 2.19 11.31-2.23 22.15-6.38 32.07-12.26a50.69 50.69 0 0 1-22.2 27.93c10.01-1.18 19.79-3.86 29-7.95a102.594 102.594 0 0 1-25.2 26.16z"
+        />
+      </svg>
+    ),
   },
 };


### PR DESCRIPTION
## Describe your changes
<!--- Thoughtfully think through your changes. Think of your audience, this PR is public! -->
I removed the custom project icon "NG". If the icon is missing, it will be a [GitHub icon](https://primer.style/octicons/mark-github-16) by default.

## Issue ticket number and link
<!--- Closed <insert issue number with #> -->
closes #622 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Clicking on the NG icons leads to the project's GitHub repo, the NG icon does not illustrate such behavior
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/nkowaokwu/igbo_api/issues/622

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I removed the project custom icon, then ran `yarn dev:site` to start front end site for the API. I saw the NG icon was replaced with the GitHub icon
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<!--- Replace this section with a screenshot or N/A if there are no screenshots -->
<img width="949" alt="Screenshot 2023-05-07 125902" src="https://user-images.githubusercontent.com/68870695/236676043-0e8c8a90-aff8-499e-8035-295fd54d8d9e.png">

