### PR TITLE
chore(docs): mention that X-API-Header is required

### DIFF
--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -48,6 +48,8 @@ Once you've configured your project, you can start the Igbo API dev server by ru
 yarn dev
 ```
 
+**Note:** All requests must be made with `X-API-Header` with the value of `main_key`.
+
 Navigate to [localhost:8080](http://localhost:8080) to see the API
 
 ## Optional: Development with Replica Sets and Redis

--- a/src/pages/docs/routes/examples.mdx
+++ b/src/pages/docs/routes/examples.mdx
@@ -19,6 +19,11 @@ GET /examples
 ```
 Get examples from dictionary
 
+ **Request Headers**
+| Name   | Description | Example |
+| :----- | :----- | :----- |
+| **X-API-Header** *required* | Secret API token | `X-API-Header=API_token` |
+
  **Parameters**
 
 | Name   | Description | Example |

--- a/src/pages/docs/routes/words.mdx
+++ b/src/pages/docs/routes/words.mdx
@@ -19,6 +19,11 @@ GET /words
 ```
 Get words from dictionary
 
+ **Request Headers**
+| Name   | Description | Example |
+| :----- | :----- | :----- |
+| **X-API-Header** *required* | Secret API token | `X-API-Header=API_token` |
+
  **Query Parameters**
 
 | Name   | Description | Example |


### PR DESCRIPTION
## Describe your changes
The documentation didn't mention that the `X-API-Header` is required. This PR mentions that requirement.

## Issue ticket number and link
N/A

## Motivation and Context
The documentation wasn't entirely clear on what's required for the server to work as expected
