### PR TITLE
Support multiple `pronunciations` in Examples

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,4 +20,4 @@ jobs:
         run: yarn install
 
       - name: Run ESLint
-        run: yarn run eslint ./src --ext .js,.jsx,.ts,.tsx -c ./.eslintrc.json
+        run: yarn run eslint ./src --ext .js,.jsx,.ts,.tsx -c ./.eslintrc.js

--- a/__tests__/examples.test.js
+++ b/__tests__/examples.test.js
@@ -112,9 +112,9 @@ describe('MongoDB Examples', () => {
   describe('/GET mongodb examples V2', () => {
     it('should return one example', async () => {
       const res = await getExamplesV2({}, { apiKey: MAIN_KEY });
-      const result = await getExampleV2(res.body[0].id);
+      const result = await getExampleV2(res.body.data[0].id);
       expect(result.status).toEqual(200);
-      Object.keys(result.body).forEach((key) => {
+      Object.keys(result.body.data).forEach((key) => {
         expect(EXAMPLE_KEYS_V2).toContain(key);
       });
     });

--- a/__tests__/shared/commands.js
+++ b/__tests__/shared/commands.js
@@ -67,13 +67,13 @@ export const getExamples = (query = {}, options = {}) => (
 /* Searches for examples using the data in MongoDB V2 */
 export const getExampleV2 = (id, query = {}, options = {}) => (
   server
-    .get(`${API_ROUTE}/examples/${id}`)
+    .get(`${API_ROUTE_V2}/examples/${id}`)
     .query(query)
     .set('X-API-Key', options.apiKey || FALLBACK_API_KEY)
 );
 export const getExamplesV2 = (query = {}, options = {}) => (
   server
-    .get(`${API_ROUTE}/examples`)
+    .get(`${API_ROUTE_V2}/examples`)
     .query(query)
     .set('X-API-Key', options.apiKey || FALLBACK_API_KEY)
 );

--- a/__tests__/shared/constants.js
+++ b/__tests__/shared/constants.js
@@ -58,7 +58,7 @@ export const EXAMPLE_KEYS_V2 = [
   'associatedDefinitionsSchemas',
   'id',
   'nsibidi',
-  'pronunciation',
+  'pronunciations',
   'updatedAt',
   'createdAt',
 ];

--- a/migrations/20230118013604-convert-stems-to-object-id.js
+++ b/migrations/20230118013604-convert-stems-to-object-id.js
@@ -3,6 +3,7 @@ const stemsToObjectIdMigrationPipeline = [
     $match: {
       'stems.0': {
         $exists: true,
+        $type: 'string',
       },
     },
   }, {

--- a/migrations/20230221011130-pronunciation-to-pronunciations.js
+++ b/migrations/20230221011130-pronunciation-to-pronunciations.js
@@ -1,0 +1,39 @@
+const pronunciationsMigrationPipeline = [
+  {
+    $set: {
+      pronunciations: [{
+        audio: '$pronunciation',
+        speaker: '',
+      }],
+    },
+  },
+  {
+    $unset: 'pronunciation',
+  },
+];
+const revertPronunciationsMigrationPipeline = [
+  {
+    $set: {
+      pronunciation: '$pronunciations.0.audio',
+    },
+  },
+  {
+    $unset: 'pronunciations',
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['examples', 'examplesuggestions'];
+    return collections.map(async (collection) => {
+      db.collection(collection).updateMany({}, pronunciationsMigrationPipeline);
+    });
+  },
+
+  async down(db) {
+    const collections = ['examples', 'examplesuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, revertPronunciationsMigrationPipeline)
+    ));
+  },
+};

--- a/migrations/20230522011130-pronunciation-to-pronunciations.js
+++ b/migrations/20230522011130-pronunciation-to-pronunciations.js
@@ -7,9 +7,7 @@ const pronunciationsMigrationPipeline = [
       }],
     },
   },
-  {
-    $unset: 'pronunciation',
-  },
+  { $unset: 'pronunciation' },
 ];
 const revertPronunciationsMigrationPipeline = [
   {
@@ -26,7 +24,14 @@ module.exports = {
   async up(db) {
     const collections = ['examples', 'examplesuggestions'];
     return collections.map(async (collection) => {
-      db.collection(collection).updateMany({}, pronunciationsMigrationPipeline);
+      db.collection(collection).updateMany(
+        { $and: [{ pronunciation: { $ne: '' } }, { pronunciation: { $ne: null } }] },
+        pronunciationsMigrationPipeline,
+      );
+      db.collection(collection).updateMany(
+        { pronunciations: { $exists: false } },
+        [{ $set: { pronunciations: [] } }, { $unset: 'pronunciation' }],
+      );
     });
   },
 

--- a/src/controllers/__tests__/examples.test.js
+++ b/src/controllers/__tests__/examples.test.js
@@ -1,0 +1,21 @@
+import { convertExamplePronunciations } from '../examples';
+
+describe('examples', () => {
+  it('converts example pronunciations to pronunciation for v1', () => {
+    const example = {
+      igbo: 'igbo',
+      english: 'english',
+      meaning: 'meaning',
+      nsibidi: 'nsibidi',
+      pronunciations: [{ audio: 'first audio', speaker: '' }],
+    };
+
+    expect(convertExamplePronunciations(example)).toEqual({
+      igbo: 'igbo',
+      english: 'english',
+      meaning: 'meaning',
+      nsibidi: 'nsibidi',
+      pronunciation: 'first audio',
+    });
+  });
+});

--- a/src/controllers/utils/buildDocs.js
+++ b/src/controllers/utils/buildDocs.js
@@ -90,6 +90,7 @@ export const findWordsWithMatch = async ({
         stems: 1,
         relatedTerms: 1,
         updatedAt: 1,
+        pronunciation: 1,
         attributes: 1,
         tenses: 1,
         examples: 1,
@@ -104,7 +105,6 @@ export const findWordsWithMatch = async ({
     const contentLength = finalWords.length;
 
     finalWords.forEach((word) => {
-      delete word.pronunciations;
       if (version === Versions.VERSION_1) {
         word.wordClass = word.definitions[0].wordClass;
         word.nsibidi = word.definitions[0].nsibidi;

--- a/src/models/Example.js
+++ b/src/models/Example.js
@@ -21,7 +21,13 @@ export const exampleSchema = new Schema({
   },
   associatedWords: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   associatedDefinitionsSchemas: { type: [{ type: Types.ObjectId }], default: [] },
-  pronunciation: { type: String, default: '' },
+  pronunciations: {
+    type: [{
+      audio: { type: String, default: '' },
+      speaker: { type: String, default: '' },
+    }],
+    default: [],
+  },
 }, { toObject: toObjectPlugin, timestamps: true });
 
 exampleSchema.index({

--- a/src/routers/routerV2.js
+++ b/src/routers/routerV2.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { getWords, getWord } from '../controllers/words';
+import { getExample, getExamples } from '../controllers/examples';
 import validId from '../middleware/validId';
 import validateApiKey from '../middleware/validateApiKey';
 import analytics from '../middleware/analytics';
@@ -9,10 +10,10 @@ const routerV2 = express.Router();
 
 routerV2.get('/words', analytics, validateApiKey, attachRedisClient, getWords);
 routerV2.get('/words/:id', analytics, validateApiKey, validId, attachRedisClient, getWord);
+routerV2.get('/examples', analytics, validateApiKey, attachRedisClient, getExamples);
+routerV2.get('/examples/:id', analytics, validateApiKey, validId, attachRedisClient, getExample);
 
 // Redirects to V1
-routerV2.get('/examples', (_, res) => res.redirect('/api/v1/examples'));
-routerV2.get('/examples/:id', (_, res) => res.redirect('/api/v1/examples/:id'));
 routerV2.post('/developers', (_, res) => res.redirect('/api/v1/developers'));
 routerV2.get('/stats', (_, res) => res.redirect('/api/v1/stats'));
 


### PR DESCRIPTION
## Describe your changes
A migration script to replace the `pronunciation` field with the new `pronunciations` field to support multiple audio recordings for each example sentence.

## Issue ticket number and link
N/A

## Motivation and Context
We want to collect a larger variety of data. In order to do this, we want to be able to support multiple audio recordings for each example sentence.

## How Has This Been Tested?
Locally ran the migration step to confirm the script will migrate all the data.

