### PR TITLE
chore: migrate example suggestions to support approvals, denials, and review

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,14 +38,15 @@ jobs:
           rm -rf ./node_modules; yarn install
           npm install -g firebase-tools
       - name: Install Cloud Dependencies
-        run: cd functions; rm -rf ./node_modules/; yarn; cd ..; pwd
+        run: |
+          cd functions; rm -rf ./node_modules/; yarn; cd ..; pwd
+          firebase use default --token $FIREBASE_TOKEN
       - name: Migrate MongoDB Data
         run: |
           firebase functions:config:set env.redis_status=true runtime.env=production --token $FIREBASE_TOKEN
           yarn migrate-up
       - name: Build Production Project
         run: |
-          firebase use default --token $FIREBASE_TOKEN
           firebase functions:config:set runtime.env=production --token $FIREBASE_TOKEN
           yarn build
       - name: Deploy to prod

--- a/migrations/20230526231511-example-suggestions-approvals-denials-review.js
+++ b/migrations/20230526231511-example-suggestions-approvals-denials-review.js
@@ -1,0 +1,66 @@
+const examplePronunciationsMigrationPipeline = [
+  {
+    $addFields: {
+      pronunciations: {
+        $function: {
+          // eslint-disable-next-line
+          body: `function(pronunciations) {
+            if (!pronunciations) {
+              return [];
+            }
+            return pronunciations.map(({ audio, speaker, _id }) => ({
+              audio,
+              speaker,
+              // eslint-disable-next-line
+              _id: _id || ObjectId(),
+              review: true,
+              approvals: [],
+              denials: [],
+            }));
+          }`,
+          args: ['$pronunciations'],
+          lang: 'js',
+        },
+      },
+    },
+  },
+];
+
+const revertPronunciationsMigrationPipeline = [
+  {
+    $addFields: {
+      pronunciations: {
+        $map: {
+          input: '$pronunciations',
+          as: 'pronunciation',
+          in: {
+            $mergeObjects: [
+              { audio: '$$pronunciation.audio' },
+              { speaker: '$$pronunciation.speaker' },
+              { _id: '$$pronunciation._id' },
+            ],
+          },
+        },
+      },
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['examplesuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany(
+        {},
+        examplePronunciationsMigrationPipeline,
+      )
+    ));
+  },
+
+  async down(db) {
+    const collections = ['examplesuggestions'];
+    return collections.map((collection) => (
+      db.collection(collection).updateMany({}, revertPronunciationsMigrationPipeline)
+    ));
+  },
+};


### PR DESCRIPTION
## Describe your changes
Migrates the ExampleSuggestion model in the Igbo API database to support `approvals`, `denials`, and `review`

## Issue ticket number and link
N/A

## Motivation and Context
Allow the Igbo API Editor Platform to approve and deny specific example suggestion audio pronunciations.

## How Has This Been Tested?
Locally migrating the database

## Screenshots (if appropriate):
N/A
