### PR TITLE
chore: trim white space throughout word documents

### DIFF
--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -1,6 +1,6 @@
 const config = {
   mongodb: {
-    url: process.env.MONGO_URI || 'mongodb://localhost:27017',
+    url: process.env.MONGO_URI || 'mongodb://0.0.0.0:27017',
     databaseName: process.env.DB_NAME || 'igbo_api',
     options: {
       useNewUrlParser: true,

--- a/migrations/20230605005447-trim-headword-and-tenses-whitespace.js
+++ b/migrations/20230605005447-trim-headword-and-tenses-whitespace.js
@@ -1,0 +1,103 @@
+const trimPipeline = [
+  {
+    $project: {
+      word: {
+        $trim: {
+          input: '$word',
+        },
+      },
+      wordPronunciation: 1,
+      conceptualWord: 1,
+      definitions: 1,
+      dialects: 1,
+      tags: 1,
+      'tenses.infinitive': {
+        $trim: {
+          input: '$tenses.infinitive',
+        },
+      },
+      'tenses.imperative': {
+        $trim: {
+          input: '$tenses.imperative',
+        },
+      },
+      'tenses.simplePast': {
+        $trim: {
+          input: '$tenses.simplePast',
+        },
+      },
+      'tenses.presentPassive': {
+        $trim: {
+          input: '$tenses.presentPassive',
+        },
+      },
+      'tenses.simplePresent': {
+        $trim: {
+          input: '$tenses.simplePresent',
+        },
+      },
+      'tenses.presentContinuous': {
+        $trim: {
+          input: '$tenses.presentContinuous',
+        },
+      },
+      'tenses.future': {
+        $trim: {
+          input: '$tenses.future',
+        },
+      },
+      attributes: 1,
+      pronunciation: 1,
+      variations: 1,
+      frequency: 1,
+      relatedTerms: 1,
+      hypernyms: 1,
+      hyponyms: 1,
+      stems: 1,
+      __v: 1,
+      updatedAt: 1,
+      createdAt: 1,
+    },
+  },
+];
+
+const revertTrimPipeline = [
+  {
+    $project: {
+      word: 1,
+      wordPronunciation: 1,
+      conceptualWord: 1,
+      definitions: 1,
+      dialects: 1,
+      tags: 1,
+      tenses: 1,
+      attributes: 1,
+      pronunciation: 1,
+      variations: 1,
+      frequency: 1,
+      relatedTerms: 1,
+      hypernyms: 1,
+      hyponyms: 1,
+      stems: 1,
+      __v: 1,
+      updatedAt: 1,
+      createdAt: 1,
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const collections = ['words', 'wordsuggestions'];
+    await Promise.all(collections.map((collection) => (
+      db.collection(collection).updateMany({}, trimPipeline)
+    )));
+  },
+
+  async down(db) {
+    const collections = ['words', 'wordsuggestions'];
+    await Promise.all(collections.map((collection) => (
+      db.collection(collection).updateMany({}, revertTrimPipeline)
+    )));
+  },
+};


### PR DESCRIPTION
## Describe your changes
Creates migration pipeline to trim whitespace specifically for headwords and tenses. Additionally, the `trim` field is added to the Mongoose Word model to prevent new documents having whitespace.

## Issue ticket number and link
N/A

## Motivation and Context
There's quite a few headwords and tenses in our database that have whitespace that is interfering with our search algorithm. 

## How Has This Been Tested?
Locally on my machine.

## Screenshots (if appropriate):
N/A
