### PR TITLE
Add prettier support to the project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-const os = require('os');
-
 module.exports = {
   env: {
     es2021: true,
@@ -7,7 +5,8 @@ module.exports = {
     jest: true,
   },
   ignorePatterns: ['**/functions/*.js'],
-  extends: ['next', 'airbnb', 'plugin:cypress/recommended'],
+  // Prettier plugin should be the last to always override preceding plugins
+  extends: ['next', 'airbnb', 'plugin:cypress/recommended', 'prettier'],
   parserOptions: {
     ecmaVersion: 12,
     sourceType: 'module',
@@ -18,20 +17,17 @@ module.exports = {
     'function-paren-newline': ['off'],
     'import/prefer-default-export': ['off'],
     'import/extensions': ['warn'],
-    'max-len': ['error', { code: 120 }],
     'newline-per-chained-call': ['off'],
     'no-console': ['off'],
     'no-nested-ternary': ['off'],
     'no-promise-executor-return': ['off'],
     'no-underscore-dangle': ['off'],
-    semi: ['error', 'always'],
     'react/jsx-filename-extension': ['off'],
     'react/function-component-definition': ['off'],
     'react/jsx-props-no-spreading': ['off'],
     'react/no-danger': ['off'],
     '@next/next/no-html-link-for-pages': ['off'],
     '@next/next/no-img-element': ['off'],
-    'linebreak-style': ['error', os.platform() === 'win32' ? 'windows' : 'unix'],
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     }
   },
   "lint-staged": {
-    "{*.js,*.ts}": [
-      "./node_modules/.bin/eslint 'src/**'"
+    "*.{js,ts}": [
+      "./node_modules/.bin/prettier --write", "./node_modules/.bin/eslint"
     ]
   },
   "license": "ISC",
@@ -167,6 +167,7 @@
     "postcss": "^8.1.3",
     "postcss-loader": "~3.0.0",
     "postcss-preset-env": "^6.7.0",
+    "prettier": "2.8.8",
     "supertest": "^6.3.1"
   },
   "standard-version": {


### PR DESCRIPTION
## Describe your changes
Installed the prettier library and updated the lint-staged script to first run the prettier command to format the file before linting. Also updated the extends field in .eslintrc.js file adding the eslint-config-prettier plugin as the last plugin in the array to override configurations from other plugins and removed three eslint rules that conflict with prettier. The removed rules where detected using the eslint-config-prettier CLI. Added support for Typescript files

## Issue ticket number and link
chore #633
## Motivation and Context
Currently, developers need to manually format all their changed files to pass the linting GitHub action #633

## How Has This Been Tested?
Tested the functionality manually, by committing an unformatted file

