### PR TITLE
chore: include @babel preset in dependencies

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -20,6 +20,7 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.7",
+    "@babel/preset-typescript": "^7.21.5",
     "@babel/runtime": "^7.20.6",
     "@chakra-ui/icons": "^1.1.1",
     "@chakra-ui/react": "^1.7.4",
@@ -81,6 +82,7 @@
     "shx": "^0.3.3",
     "string-similarity": "^4.0.2",
     "tailwindcss": "3",
+    "typescript": "^5.1.3",
     "unicharadata": "^9.0.0-alpha.6",
     "uuid": "^8.3.2",
     "yarn": "^1.22.10"

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "./node_modules/.bin/eslint"
+    "{*.js,*.ts}": [
+      "./node_modules/.bin/eslint 'src/**'"
     ]
   },
   "license": "ISC",
@@ -70,6 +70,7 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.7",
+    "@babel/preset-typescript": "^7.21.5",
     "@babel/runtime": "^7.20.6",
     "@chakra-ui/icons": "^1.1.1",
     "@chakra-ui/react": "^1.7.4",
@@ -131,12 +132,12 @@
     "shx": "^0.3.3",
     "string-similarity": "^4.0.2",
     "tailwindcss": "3",
+    "typescript": "^5.1.3",
     "unicharadata": "^9.0.0-alpha.6",
     "uuid": "^8.3.2",
     "yarn": "^1.22.10"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.21.5",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@semantic-release/changelog": "^5.0.1",
@@ -166,8 +167,7 @@
     "postcss": "^8.1.3",
     "postcss-loader": "~3.0.0",
     "postcss-preset-env": "^6.7.0",
-    "supertest": "^6.3.1",
-    "typescript": "5.0.4"
+    "supertest": "^6.3.1"
   },
   "standard-version": {
     "skip": {


### PR DESCRIPTION
## Describe your changes
Moves Babel and Typescript `devDependencies` to `dependencies`

## Issue ticket number and link
N/A

## Motivation and Context
Our deploy pipeline has been blocked for two weeks 😱 

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
N/A
