### PR TITLE
build: update github actions checkout version

### DIFF
--- a/.github/workflows/audio_backup.yml
+++ b/.github/workflows/audio_backup.yml
@@ -28,7 +28,7 @@ jobs:
       # Skipping the following steps to prioritize using AWS S3 Glacier
 
       # - name: Git checkout files and create aws db directory
-      #   uses: actions/checkout@v2
+      #   uses: actions/checkout@v3
       # - name: Set up network configurations
       #   run: sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
       # - name: Create temporary directory

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git checkout files and create db directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - shell: bash
         env:
           MONGO_URI: ${{ secrets.MONGO_URI }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v2.1.2
         with:

--- a/.github/workflows/dockerize.yml
+++ b/.github/workflows/dockerize.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js @18
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use Node.js @${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js v18
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## Describe your changes
The PR upgrades the actions checkout from version 2 to version 3.

## Issue ticket number and link
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The version 2 of Github actions checkout uses node 12 which is no longer a supported version of NodeJs and is also deprecated for Github Action.


## Screenshots (if appropriate):
N/A
