### PR TITLE
Fix `yarn build` for Windows Users

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "main": "server.js",
   "scripts": {
     "build": "rm -rf dist/ && yarn build:site && yarn build:src && cross-env NODE_ENV=build yarn build:dictionaries && yarn build:functions",
-    "build:functions": "rm -rf functions/src && shx cp -r ./dist ./functions/src && cp -r ./dist/dictionaries/ig-en ./functions/src/dictionaries",
+    "build:functions": "rm -rf functions/src && shx cp -r ./dist ./functions/src && shx cp -r ./dist/dictionaries/ig-en ./functions/src/dictionaries",
     "build:src": "babel -d dist/ ./src -s --extensions '.js,.jsx,.ts,.tsx'",
-    "prebuild:dictionaries": "shx cp -r ./src/dictionaries/ig-en ./dist/dictionaries/ig-en && shx cp -r ./src/dictionaries/en-ig ./dist/dictionaries/en-ig",
+    "build:dictionaries:ig:en": "[ ! -d \"./dist/dictionaries\" ] && shx mkdir ./dist/dictionaries || echo '' && [ ! -d \"./dist/dictionaries/ig-en\" ] && shx mkdir ./dist/dictionaries/ig-en || echo 'Igbo to English dictionaries dir already exists'",
+    "build:dictionaries:en:ig": "[ ! -d \"./dist/dictionaries\" ] && shx mkdir ./dist/dictionaries || echo '' && [ ! -d \"./dist/dictionaries/en-ig\" ] && shx mkdir ./dist/dictionaries/en-ig || echo 'English to Igbo dictionaries dir already exists'",
+    "prebuild:dictionaries": "yarn build:dictionaries:ig:en && yarn build:dictionaries:en:ig && shx cp -r ./src/dictionaries/ig-en ./dist/dictionaries && shx cp -r ./src/dictionaries/en-ig ./dist/dictionaries",
     "build:dictionaries": "node dist/dictionaries/buildDictionaries.js",
     "build:site": "cross-env NEXT_PUBLIC_GA_ID=$GA_TRACKING_ID next build && yarn build:fonts && yarn build:assets",
     "build:fonts": "shx cp -r ./src/public/fonts/ ./dist/fonts",


### PR DESCRIPTION
## Describe your changes
Introduces new `package.json` build-related scripts to generate directories that are needed to complete the `build` script.

## Issue ticket number and link
N/A

## Motivation and Context
Many Windows Users were unable to build the project because a directory wasn't existing while `yarn build` was running.

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):
N/A
