### PR TITLE
chore: allow Windows machines to build the project fully

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ To run this project locally, please install the following:
 
 - [Node.js](https://nodejs.org/en/download/)
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
-- [MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
+- [Mongo for Windows](https://www.mongodb.com/docs/v3.0/tutorial/install-mongodb-on-windows/)
+- [Mongo for Mac](https://www.mongodb.com/docs/v3.0/tutorial/install-mongodb-on-os-x/)
 - [Firebase](https://console.firebase.google.com/)
 - [Java](https://www.oracle.com/java/technologies/downloads/)
 - [NVM](https://github.com/nvm-sh/nvm)
+- [MongoDB Compass](https://docs.mongodb.com/manual/administration/install-community/) (Optional)
 
 ### 1. Installation
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rm -rf dist/ && yarn build:site && yarn build:src && cross-env NODE_ENV=build yarn build:dictionaries && yarn build:functions",
     "build:functions": "rm -rf functions/src && shx cp -r ./dist ./functions/src && shx cp -r ./dist/dictionaries/ig-en ./functions/src/dictionaries",
-    "build:src": "babel -d dist/ ./src -s --extensions '.js,.jsx,.ts,.tsx'",
+    "build:src": "bash ./scripts/build_src.sh",
     "build:dictionaries:ig:en": "[ ! -d \"./dist/dictionaries\" ] && shx mkdir ./dist/dictionaries || echo '' && [ ! -d \"./dist/dictionaries/ig-en\" ] && shx mkdir ./dist/dictionaries/ig-en || echo 'Igbo to English dictionaries dir already exists'",
     "build:dictionaries:en:ig": "[ ! -d \"./dist/dictionaries\" ] && shx mkdir ./dist/dictionaries || echo '' && [ ! -d \"./dist/dictionaries/en-ig\" ] && shx mkdir ./dist/dictionaries/en-ig || echo 'English to Igbo dictionaries dir already exists'",
     "prebuild:dictionaries": "yarn build:dictionaries:ig:en && yarn build:dictionaries:en:ig && shx cp -r ./src/dictionaries/ig-en ./dist/dictionaries && shx cp -r ./src/dictionaries/en-ig ./dist/dictionaries",

--- a/scripts/build_src.sh
+++ b/scripts/build_src.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+babel -d dist/ ./src -s --extensions '.js,.jsx,.ts,.tsx'


### PR DESCRIPTION
## Describe your changes
Introduce the `build_src.sh` bash script to successfully `babel`

## Issue ticket number and link
N/A

## Motivation and Context
Windows users have been unable to successfully build the project when running `yarn build`. 

## How Has This Been Tested?
Locally and manually

## Screenshots (if appropriate):
N/A
