### PR TITLE
docs: correct api key header name in docs Fixes #742

### DIFF
--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -48,7 +48,7 @@ Once you've configured your project, you can start the Igbo API dev server by ru
 yarn dev
 ```
 
-**Note:** All requests must be made with `X-API-Header` with the value of `main_key`.
+**Note:** All requests must be made with `X-API-Key` with the value of `main_key`.
 
 Navigate to [localhost:8080](http://localhost:8080) to see the API
 

--- a/src/pages/docs/routes/examples.mdx
+++ b/src/pages/docs/routes/examples.mdx
@@ -22,7 +22,7 @@ Get examples from dictionary
  **Request Headers**
 | Name   | Description | Example |
 | :----- | :----- | :----- |
-| **X-API-Header** *required* | Secret API token | `X-API-Header=API_token` |
+| **X-API-Key** *required* | Secret API token | `X-API-Key=API_token` |
 
  **Parameters**
 

--- a/src/pages/docs/routes/words.mdx
+++ b/src/pages/docs/routes/words.mdx
@@ -22,7 +22,7 @@ Get words from dictionary
  **Request Headers**
 | Name   | Description | Example |
 | :----- | :----- | :----- |
-| **X-API-Header** *required* | Secret API token | `X-API-Header=API_token` |
+| **X-API-Key** *required* | Secret API token | `X-API-Key=API_token` |
 
  **Query Parameters**
 


### PR DESCRIPTION
## Describe your changes
Changed the header name for the API key on the docs from `X-API-Header` to `X-API-Key`, which is what the app actually looks for.

## Issue ticket number and link
Closed #742 

## Motivation and Context
Gives a better and easier experience to future developers that use the docs.


## How Has This Been Tested?
This should not be a breaking change to the application.