### PR TITLE
chore: log query builders to understand regex size limit

### DIFF
--- a/src/controllers/utils/buildDocs.ts
+++ b/src/controllers/utils/buildDocs.ts
@@ -45,14 +45,16 @@ export const findWordsWithMatch = async ({
   match,
   version,
   lean = false,
+  queryLabel = '',
 }: {
   match: PipelineStage.Match['$match'];
   version: Version;
   lean?: boolean;
+  queryLabel?: string;
 }) => {
   const connection = createDbConnection();
   const Word = connection.model<WordDocument>('Word', wordSchema);
-  console.time('Aggregation completion time');
+  console.time(`Aggregation completion time: ${queryLabel || 'N/A'}`);
   try {
     let words = generateAggregationBase<WordDocument>(Word, match);
 
@@ -125,11 +127,13 @@ export const findWordsWithMatch = async ({
       return cleanedWord as WordDocument;
     });
 
-    console.timeEnd('Aggregation completion time');
+    console.log('first', queryLabel);
+    console.timeEnd(`Aggregation completion time: ${queryLabel || 'N/A'}`);
     await handleCloseConnection(connection);
     return { words: finalWords, contentLength };
   } catch (err: any) {
-    console.timeEnd('Aggregation completion time');
+    console.log('second', queryLabel);
+    console.timeEnd(`Aggregation completion time: ${queryLabel || 'N/A'}`);
     await handleCloseConnection(connection);
     throw err;
   }

--- a/src/controllers/utils/minimizeWords.js
+++ b/src/controllers/utils/minimizeWords.js
@@ -6,34 +6,34 @@ const minimizeWords = (words, version) => {
   const minimizedWords = words.map((word) => {
     let minimizedWord = assign(word);
     minimizedWord = omit(minimizedWord, ['hypernyms', 'hyponyms', 'updatedAt', 'createdAt']);
-    minimizedWord.definitions = version === Version.VERSION_2 ? (minimizedWord.definitions || []).map((definition) => {
-      let minimizedDefinition = assign(definition);
-      minimizedDefinition = omit(minimizedDefinition, ['label', 'igboDefinitions', '_id', 'id']);
-      if (!minimizedDefinition.nsibidi) {
-        minimizedDefinition = omit(minimizedDefinition, ['nsibidi']);
-      }
-      return minimizedDefinition;
-    }) : minimizedWord.definitions;
+    minimizedWord.definitions =
+      version === Version.VERSION_2
+        ? (minimizedWord.definitions || []).map((definition) => {
+            let minimizedDefinition = assign(definition);
+            minimizedDefinition = omit(minimizedDefinition, ['label', 'igboDefinitions', '_id', 'id']);
+            if (!minimizedDefinition.nsibidi) {
+              minimizedDefinition = omit(minimizedDefinition, ['nsibidi']);
+            }
+            return minimizedDefinition;
+          })
+        : minimizedWord.definitions;
     if (!minimizedWord.variations?.length) {
       minimizedWord = omit(minimizedWord, ['variations']);
     }
     if (minimizedWord.examples?.length) {
       minimizedWord.examples = minimizedWord.examples?.map((example) => {
         let minimizedExample = assign(example);
-        minimizedExample = omit(
-          example,
-          [
-            'associatedWords',
-            'pronunciation',
-            'updatedAt',
-            'createdAt',
-            'meaning',
-            'style',
-            'associatedDefinitionsSchemas',
-            'archived',
-            'id',
-          ],
-        );
+        minimizedExample = omit(example, [
+          'associatedWords',
+          'pronunciation',
+          'updatedAt',
+          'createdAt',
+          'meaning',
+          'style',
+          'associatedDefinitionsSchemas',
+          'archived',
+          'id',
+        ]);
         if (!minimizedExample.nsibidi) {
           minimizedExample = omit(minimizedExample, ['nsibidi']);
         }

--- a/src/controllers/utils/queries.js
+++ b/src/controllers/utils/queries.js
@@ -18,7 +18,7 @@ const generateMultipleWordRegex = (keywords) => {
 };
 
 const generateMultipleDefinitionsRegex = (keywords) => ({
-  'definitions.definitions': { $in: keywords.map(({ regex }) => regex.definitionsReg) },
+  'definitions.definitions': { $in: compact(keywords.map(({ regex }) => regex.definitionsReg)) },
 });
 
 const generateMultipleVariationsRegex = (keywords) => {

--- a/src/controllers/utils/searchWordUsingIgbo.ts
+++ b/src/controllers/utils/searchWordUsingIgbo.ts
@@ -1,4 +1,5 @@
 import { RedisClientType } from 'redis';
+import fs from 'fs';
 import { compact, uniqWith } from 'lodash';
 import { searchIgboTextSearch, strictSearchIgboQuery, searchDefinitionsWithinIgboTextSearch } from './queries';
 import { findWordsWithMatch } from './buildDocs';
@@ -70,8 +71,8 @@ const searchWordUsingIgbo = async ({
     });
     console.time(`Searching Igbo words for ${searchWord}`);
     const [igboResults, englishResults] = await Promise.all([
-      findWordsWithMatch({ match: igboQuery, version }),
-      findWordsWithMatch({ match: definitionsWithinIgboQuery, version }),
+      findWordsWithMatch({ match: igboQuery, version, queryLabel: 'igbo' }),
+      findWordsWithMatch({ match: definitionsWithinIgboQuery, version, queryLabel: 'definitions' }),
     ]);
     console.timeEnd(`Searching Igbo words for ${searchWord}`);
     // Prevents from duplicate word documents from being included in the final words array
@@ -94,7 +95,7 @@ const searchWordUsingIgbo = async ({
   let sortedWords = sortDocsBy(searchWord, responseData.words, 'word', version, regex);
   sortedWords = sortedWords.slice(skip, skip + limit);
 
-  console.time(`searchWordUsingIgbo for ${searchWord}`);
+  console.timeEnd(`searchWordUsingIgbo for ${searchWord}`);
   return handleWordFlags({
     data: { words: sortedWords, contentLength: responseData.contentLength },
     flags,


### PR DESCRIPTION
## Describe your changes
Adds more logging details to debug production bugs

## Issue ticket number and link
N/A

## Motivation and Context
Currently, there's a bug within GCP stating that our RegExps are too large, however, we don't know why we're hitting that limit. This PR is the first step in us understanding why the error is getting thrown and how we can fix it.

## How Has This Been Tested?
Locally on my machine. No new tests.

## Screenshots (if appropriate):
N/A
