### PR TITLE
fix: check to see if word is english before searching

### DIFF
--- a/@types/is-word.d.ts
+++ b/@types/is-word.d.ts
@@ -1,0 +1,1 @@
+declare module 'is-word';

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "firebase-tools": "^11.30.0",
     "framer-motion": "^5",
     "i18next": "^21.6.5",
+    "is-word": "^1.0.4",
     "jest": "^29.2.2",
     "joi": "^17.4.0",
     "lodash": "^4.17.20",

--- a/src/controllers/words.ts
+++ b/src/controllers/words.ts
@@ -1,5 +1,6 @@
 import map from 'lodash/map';
 import mongoose from 'mongoose';
+import isWord from 'is-word';
 import removePrefix from '../shared/utils/removePrefix';
 import { findSearchWord } from '../services/words';
 import { NO_PROVIDED_TERM } from '../shared/constants/errorMessages';
@@ -15,6 +16,8 @@ import { handleWordFlags } from '../APIs/FlagsAPI';
 import minimizeWords from './utils/minimizeWords';
 import { Express, LegacyWord } from '../types';
 import { WordResponseData } from './types';
+
+const isEnglish = isWord('american-english');
 
 /* Gets words from JSON dictionary */
 export const getWordData: Express.MiddleWare = (req, res, next) => {
@@ -57,7 +60,8 @@ const getWordsFromDatabase: Express.MiddleWare = async (req, res, next) => {
       filters,
     };
     let responseData: WordResponseData = { words: [], contentLength: 0 };
-    if (hasQuotes) {
+    const isSearchWordEnglish = isEnglish.check(searchWord) && !!searchWord;
+    if (hasQuotes || isSearchWordEnglish) {
       responseData = await searchWordUsingEnglish({
         redisClient,
         version,


### PR DESCRIPTION
## Describe your changes
Uses the [`is-english`](https://www.npmjs.com/package/is-english) npm package to check whether the search word is in English or not.

## Issue ticket number and link
N/A

## Motivation and Context
A lot of unrelated words would be returned when simple English terms were searched by users (i.e. apricot, beautiful, thought, etc.) With this change, only relevant word entries will be returned to the user. 

## How Has This Been Tested?
Locally on my machine.

## Screenshots (if appropriate):
N/A
