### PR TITLE
chore: remove console.log and console.time to reduce logging costs in GCP

### DIFF
--- a/src/APIs/FlagsAPI.ts
+++ b/src/APIs/FlagsAPI.ts
@@ -14,7 +14,6 @@ export const handleWordFlags = ({
   data: { words, contentLength },
   flags: { examples, dialects, resolve },
 }: HandleFlags) => {
-  console.time(`Handling word flags - examples: ${examples}, dialects: ${dialects}, resolve: ${resolve}`);
   const updatedWords = compact(
     words.map((word: Word | WordDocument | LegacyWordDocument) => {
       let updatedWord: PartialWordType = assign(word);
@@ -41,6 +40,5 @@ export const handleWordFlags = ({
       return updatedWord;
     })
   );
-  console.timeEnd(`Handling word flags - examples: ${examples}, dialects: ${dialects}, resolve: ${resolve}`);
   return { words: updatedWords, contentLength };
 };

--- a/src/APIs/RedisAPI.ts
+++ b/src/APIs/RedisAPI.ts
@@ -20,11 +20,8 @@ type GetValue = {
 };
 
 export const getCachedWords = async ({ key, redisClient = defaultRedisClient }: GetValue) => {
-  console.time('Getting cached words');
   const rawCachedWords = await redisClient.get(key);
   const cachedWords = typeof rawCachedWords === 'string' ? JSON.parse(rawCachedWords) : rawCachedWords;
-  console.log(`Retrieved cached data for words ${key}:`, !!cachedWords);
-  console.timeEnd('Getting cached words');
   return cachedWords;
 };
 
@@ -53,7 +50,6 @@ export const setCachedWords = async ({
 export const getCachedExamples = async ({ key, redisClient = defaultRedisClient }: GetValue) => {
   const rawCachedExamples = await redisClient.get(key);
   const cachedExamples = typeof rawCachedExamples === 'string' ? JSON.parse(rawCachedExamples) : rawCachedExamples;
-  console.log(`Retrieved cached data for examples ${key}:`, !!cachedExamples);
   return cachedExamples;
 };
 
@@ -73,15 +69,12 @@ export const setCachedExamples = async ({
 };
 
 export const getAllCachedVerbsAndSuffixes = async ({ key, redisClient = defaultRedisClient }: GetValue) => {
-  console.time(`Searching cached verbs and suffixes: verbs-and-suffixes-${key}`);
   const redisAllVerbsAndSuffixesKey = `verbs-and-suffixes-${key}`;
   const rawCachedAllVerbsAndSuffixes = await redisClient.get(redisAllVerbsAndSuffixesKey);
   const cachedAllVerbsAndSuffixes =
     typeof rawCachedAllVerbsAndSuffixes === 'string'
       ? JSON.parse(rawCachedAllVerbsAndSuffixes)
       : rawCachedAllVerbsAndSuffixes;
-  console.log(`Retrieved cached data for verbs and suffixes ${key}:`, !!cachedAllVerbsAndSuffixes);
-  console.timeEnd(`Searching cached verbs and suffixes: verbs-and-suffixes-${key}`);
   return cachedAllVerbsAndSuffixes;
 };
 
@@ -101,6 +94,5 @@ export const setAllCachedVerbsAndSuffixes = async ({
   if (!redisClient.isFake) {
     await redisClient.set(redisAllVerbsAndSuffixesKey, JSON.stringify(updatedData), { EX: REDIS_CACHE_EXPIRATION });
   }
-  console.log(`Setting verbs and suffixes cache: ${JSON.stringify(updatedData, null, 2).length}`);
   return updatedData;
 };

--- a/src/controllers/utils/buildDocs.ts
+++ b/src/controllers/utils/buildDocs.ts
@@ -60,7 +60,6 @@ export const findWordsWithMatch = async ({
 }) => {
   const connection = createDbConnection();
   const Word = connection.model<WordDocument>('Word', wordSchema);
-  console.time(`Aggregation completion time: ${queryLabel || 'N/A'}`);
   try {
     let words = generateAggregationBase<WordDocument>(Word, match);
 
@@ -133,12 +132,10 @@ export const findWordsWithMatch = async ({
       return cleanedWord as WordDocument;
     });
 
-    console.timeEnd(`Aggregation completion time: ${queryLabel || 'N/A'}`);
     await handleCloseConnection(connection);
     return { words: finalWords, contentLength };
   } catch (err: any) {
     console.log('An error occurred', err);
-    console.timeEnd(`Aggregation completion time: ${queryLabel || 'N/A'}`);
     await handleCloseConnection(connection);
     throw err;
   }

--- a/src/controllers/utils/expandNoun.ts
+++ b/src/controllers/utils/expandNoun.ts
@@ -78,7 +78,6 @@ export default (rawWord: string, wordData: WordData): Solution[] => {
       ({ wordClass: nestedWordClass }) => nestedWordClass === WordClassEnum.AV || nestedWordClass === WordClassEnum.PV
     )
   );
-  console.time('Expand noun time');
   helper(word, { verbs }, firstPointer, secondPointer, [], { depth: 0 });
   const finalSolution =
     compact(
@@ -92,7 +91,5 @@ export default (rawWord: string, wordData: WordData): Solution[] => {
         return solution;
       })
     ) || [];
-  console.timeEnd('Expand noun time');
-  console.log('Expanded noun: ', finalSolution);
   return finalSolution;
 };

--- a/src/controllers/utils/expandVerb.ts
+++ b/src/controllers/utils/expandVerb.ts
@@ -280,8 +280,6 @@ export default (rawWord: string, wordData: WordData): Solution[] => {
         nestedWordClassEnum === WordClassEnum.ESUF || nestedWordClassEnum === WordClassEnum.ISUF
     )
   );
-  console.time('Expand verb time');
-  console.log('Expanding word: ', word);
   helper(word, { verbs, suffixes: wordSuffixes }, firstPointer, secondPointer, [], { depth: 0 });
   const finalSolution =
     compact(
@@ -297,7 +295,5 @@ export default (rawWord: string, wordData: WordData): Solution[] => {
         return solution;
       })
     ) || [];
-  console.timeEnd('Expand verb time');
-  console.log('Expanded verb: ', finalSolution);
   return finalSolution;
 };

--- a/src/controllers/utils/index.ts
+++ b/src/controllers/utils/index.ts
@@ -119,7 +119,6 @@ export const handleQueries = async ({
     wordClasses: wordClassesQuery,
     resolve: resolveQuery,
   } = query;
-  console.time('Handling queries');
   const { id } = params;
   let allVerbsAndSuffixes: WordData = { verbs: [], suffixes: [] };
   const hasQuotes = keywordQuery && keywordQuery.match(/["'].*["']/) !== null;
@@ -128,12 +127,9 @@ export const handleQueries = async ({
   const allVerbsAndSuffixesQuery: PipelineStage.Match['$match'] = searchForAllVerbsAndSuffixesQuery();
   const cachedAllVerbsAndSuffixes = await getAllCachedVerbsAndSuffixes({ key: version, redisClient });
   if (version === Version.VERSION_2) {
-    console.time('Searching all verbs and suffixes');
     if (cachedAllVerbsAndSuffixes) {
-      console.log('Getting all verbs and suffixes from cache');
       allVerbsAndSuffixes = cachedAllVerbsAndSuffixes;
     } else {
-      console.log('Getting all verbs and suffixes from database');
       const allVerbsAndSuffixesDb = (await searchAllVerbsAndSuffixes({ query: allVerbsAndSuffixesQuery, version }))
         .words;
       allVerbsAndSuffixes = await setAllCachedVerbsAndSuffixes({
@@ -143,9 +139,7 @@ export const handleQueries = async ({
         version,
       });
     }
-    console.timeEnd('Searching all verbs and suffixes');
   }
-  console.time('Generating filters, searchWord, and regexes');
   const filter = convertFilterToKeyword(filterQuery);
   const searchWord = removePrefix(keyword || filter || '').replace(/[Aa]na m /, 'm ');
   const searchWordParts = compact(searchWord.split(' '));
@@ -157,9 +151,6 @@ export const handleQueries = async ({
     }),
     {}
   );
-  console.timeEnd('Generating filters, searchWord, and regexes');
-  console.log('Word splits:', searchWordParts);
-  console.log(`Search word: ${searchWord}`);
   let keywords =
     version === Version.VERSION_2 && searchWord
       ? expandVerb(searchWord, allVerbsAndSuffixes).map(({ text, wordClass }) => {
@@ -180,7 +171,6 @@ export const handleQueries = async ({
       : [];
   // Attempt to breakdown as noun if there is no breakdown as verb
   if (!keywords.length && searchWord) {
-    console.time('Attempting to breakdown noun');
     keywords =
       version === Version.VERSION_2
         ? expandNoun(searchWord, allVerbsAndSuffixes).map(({ text, wordClass }) => ({
@@ -195,15 +185,12 @@ export const handleQueries = async ({
             ),
           }))
         : [];
-    console.timeEnd('Attempting to breakdown noun');
   }
   if (!keywords.length && searchWord) {
-    console.time('Expand phrase time');
     keywords = (
       version === Version.VERSION_2
-        ? searchWordParts.map((searchWordPart, searchWordPartIndex) => {
+        ? searchWordParts.map((searchWordPart) => {
             const expandedVerb = expandVerb(searchWordPart, allVerbsAndSuffixes);
-            console.time(`Expand phrase part ${searchWordPartIndex}`);
             const result = expandedVerb.length
               ? expandedVerb.map(({ text, wordClass }) => ({
                   text,
@@ -218,14 +205,12 @@ export const handleQueries = async ({
                 }))
               : // @ts-expect-error no index signature with parameter type string
                 [{ text: searchWordPart, wordClass: [], regex: regexes[searchWordPart] }];
-            console.timeEnd(`Expand phrase part ${searchWordPartIndex}`);
+
             return result;
           })
         : []
     ).flat();
-    console.timeEnd('Expand phrase time');
   }
-  console.time('Generating page, rank, skip, limit, and other flags');
   const page = parseInt(pageQuery, 10);
   const range = parseRange(rangeQuery);
   const { skip, limit } = convertToSkipAndLimit({ page, range });
@@ -254,8 +239,6 @@ export const handleQueries = async ({
     ...(tags?.length ? { tags: { $in: tags } } : {}),
     ...(wordClasses?.length ? { 'definitions.wordClass': { $in: wordClasses } } : {}),
   };
-  console.timeEnd('Generating page, rank, skip, limit, and other flags');
-  console.timeEnd('Handling queries');
   return {
     id,
     version,

--- a/src/controllers/utils/minimizeVerbsAndSuffixes.ts
+++ b/src/controllers/utils/minimizeVerbsAndSuffixes.ts
@@ -11,7 +11,6 @@ const isVerb = (wordClass: WordClassEnum) =>
   wordClass === WordClassEnum.MV;
 
 const minimizeVerbsAndSuffixes = (words: Word[], version: Version) => {
-  console.time('Minimize words');
   const minimizedWords = words.reduce(
     (finalVerbsAndSuffixes, word) => {
       const minimizedWord = pick(assign(word), ['word', 'definitions']) as MinimizedWord;
@@ -28,7 +27,6 @@ const minimizeVerbsAndSuffixes = (words: Word[], version: Version) => {
     },
     { verbs: [], suffixes: [] } as { verbs: MinimizedWord[]; suffixes: MinimizedWord[] }
   );
-  console.timeEnd('Minimize words');
   return minimizedWords;
 };
 

--- a/src/controllers/utils/minimizeWords.ts
+++ b/src/controllers/utils/minimizeWords.ts
@@ -13,7 +13,6 @@ type MinimizedWord = Omit<PartialWordType, 'definitions' | 'examples' | 'dialect
   stems?: (string | Partial<{ id: string; _id?: Types.ObjectId }>)[];
 };
 const minimizeWords = (words: PartialWordType[], version: Version) => {
-  console.time('Minimize words');
   const minimizedWords = words.map((word) => {
     let minimizedWord: Partial<MinimizedWord> = assign(word);
     minimizedWord = omit(minimizedWord, ['hypernyms', 'hyponyms', 'updatedAt', 'createdAt']);
@@ -102,7 +101,6 @@ const minimizeWords = (words: PartialWordType[], version: Version) => {
     }
     return minimizedWord;
   });
-  console.timeEnd('Minimize words');
   return minimizedWords;
 };
 

--- a/src/controllers/utils/searchWordUsingEnglish.ts
+++ b/src/controllers/utils/searchWordUsingEnglish.ts
@@ -33,22 +33,18 @@ const searchWordUsingEnglish = async ({
   flags,
   filters,
 }: EnglishSearch) => {
-  console.time(`searchWordUsingEnglish for ${searchWord}`);
   let responseData = { words: [], contentLength: 0 };
   const redisWordsCacheKey = `"${searchWord}"-${version}`;
   const cachedWords = await getCachedWords({ key: redisWordsCacheKey, redisClient });
 
   if (cachedWords) {
-    console.log('Return words from cache for English search');
     responseData = {
       words: cachedWords.words,
       contentLength: cachedWords.contentLength,
     };
   } else {
     const query = searchEnglishRegexQuery({ regex, searchWord, filters });
-    console.time(`Searching English words for ${searchWord}`);
     const { words, contentLength } = await findWordsWithMatch({ match: query, version });
-    console.timeEnd(`Searching English words for ${searchWord}`);
     responseData = await setCachedWords({
       key: redisWordsCacheKey,
       data: { words, contentLength },
@@ -61,7 +57,6 @@ const searchWordUsingEnglish = async ({
   let sortedWords = sortDocsBy(searchWord, responseData.words, sortKey, version, regex);
   sortedWords = sortedWords.slice(skip, skip + limit);
 
-  console.timeEnd(`searchWordUsingEnglish for ${searchWord}`);
   return handleWordFlags({
     data: { words: sortedWords, contentLength: responseData.contentLength },
     flags,

--- a/src/controllers/utils/searchWordUsingIgbo.ts
+++ b/src/controllers/utils/searchWordUsingIgbo.ts
@@ -43,13 +43,11 @@ const searchWordUsingIgbo = async ({
   flags,
   filters,
 }: IgboSearch) => {
-  console.time(`searchWordUsingIgbo for ${searchWord}`);
   let responseData = { words: [], contentLength: 0 };
   const redisWordsCacheKey = `${searchWord}-${version}`;
   const cachedWords = await getCachedWords({ key: redisWordsCacheKey, redisClient });
 
   if (cachedWords) {
-    console.log('Return words from cache for Igbo search');
     responseData = {
       words: cachedWords.words,
       contentLength: cachedWords.contentLength,
@@ -70,12 +68,10 @@ const searchWordUsingIgbo = async ({
       searchWord,
       filters,
     });
-    console.time(`Searching Igbo words for ${searchWord}`);
     const [igboResults, englishResults] = await Promise.all([
       findWordsWithMatch({ match: igboQuery, version, queryLabel: 'igbo' }),
       findWordsWithMatch({ match: definitionsWithinIgboQuery, version, queryLabel: 'definitions' }),
     ]);
-    console.timeEnd(`Searching Igbo words for ${searchWord}`);
     // Prevents from duplicate word documents from being included in the final words array
     const words = searchWord
       ? uniqWith(
@@ -96,7 +92,6 @@ const searchWordUsingIgbo = async ({
   let sortedWords = sortDocsBy(searchWord, responseData.words, 'word', version, regex);
   sortedWords = sortedWords.slice(skip, skip + limit);
 
-  console.timeEnd(`searchWordUsingIgbo for ${searchWord}`);
   return handleWordFlags({
     data: { words: sortedWords, contentLength: responseData.contentLength },
     flags,

--- a/src/controllers/words.ts
+++ b/src/controllers/words.ts
@@ -38,7 +38,6 @@ export const getWordData: MiddleWare = (req, res, next) => {
 /* Reuseable base controller function for getting words */
 const getWordsFromDatabase: MiddleWare = async (req, res, next) => {
   try {
-    console.time('Getting words from database');
     const {
       version,
       searchWord,
@@ -81,8 +80,6 @@ const getWordsFromDatabase: MiddleWare = async (req, res, next) => {
         ...searchQueries,
       });
     }
-    console.log(`Number of words for search word "${searchWord}": ${responseData.contentLength}`);
-    console.timeEnd('Getting words from database');
     return packageResponse({
       res,
       docs: responseData.words,

--- a/src/middleware/analytics.ts
+++ b/src/middleware/analytics.ts
@@ -35,38 +35,30 @@ const trackEvent = ({ clientIdentifier, category, action, keyword }: TrackingEve
 
     // Avoid sending GA events
     if (isProduction) {
-      console.time('Sending production tracking data');
       axios({
         method: 'post',
         url: `${GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
         data,
       })
-        .then((res) => {
-          console.log('Logging the data:', JSON.parse(data), JSON.parse(data).events[0].params);
-          console.log({ status: res.status, response: res.data });
-          console.timeEnd('Sending production tracking data');
+        .then(() => {
           resolve(true);
         })
         .catch((err: any) => {
           console.log(typeof err?.toJSON === 'function' ? err.toJSON() : err);
-          console.timeEnd('Sending production tracking data');
           reject(new Error(err));
         });
     } else {
-      console.time('Sending development tracking data');
       axios({
         method: 'post',
         url: `${DEBUG_GA_URL}?measurement_id=${params.measurement_id}&api_secret=${params.api_secret}`,
         data,
       })
         .then(() => {
-          console.timeEnd('Sending development tracking data');
           resolve(true);
         })
         .catch((err: any) => {
           if (isProduction) {
             console.log(typeof err?.toJSON === 'function' ? err.toJSON() : err);
-            console.timeEnd('Sending development tracking data');
             reject(new Error(err));
           }
         });

--- a/src/middleware/validateApiKey.ts
+++ b/src/middleware/validateApiKey.ts
@@ -31,12 +31,10 @@ const handleDeveloperUsage = async (developer: DeveloperDocument) => {
 
 /* Finds a developer with provided information */
 const findDeveloper = async (apiKey: string) => {
-  console.time('Finding developer account');
   const connection = createDbConnection();
   const Developer = connection.model<DeveloperDocument>('Developer', developerSchema);
   let developer = await Developer.findOne({ apiKey });
   if (developer) {
-    console.timeEnd('Finding developer account');
     return developer;
   }
   // Legacy implementation: hashed API tokens can't be indexed
@@ -47,10 +45,8 @@ const findDeveloper = async (apiKey: string) => {
   if (developer) {
     developer.apiKey = apiKey;
     const updatedDeveloper = await developer.save();
-    console.timeEnd('Finding developer account');
     return updatedDeveloper;
   }
-  console.timeEnd('Finding developer account');
   return developer;
 };
 

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose';
-import { MONGO_URI, isProduction, isTest } from '../config';
+import { MONGO_URI, isTest } from '../config';
 
 const DISCONNECTED = 0;
 
@@ -11,13 +11,7 @@ export const createDbConnection = (): mongoose.Connection => {
     readPreference: isTest ? 'primary' : 'nearest',
   });
 
-  console.log('Attempting MongoDB URI:', MONGO_URI);
   connection.on('error', console.error.bind(console, 'connection error:'));
-  connection.once('open', () => {
-    if (isProduction) {
-      console.log('🗄 Database is connected', process.env.CI, MONGO_URI);
-    }
-  });
   return connection;
 };
 
@@ -26,11 +20,6 @@ export const disconnectDatabase = (): void => {
   const db = mongoose.connection;
   if (db.readyState !== DISCONNECTED) {
     db.close();
-    db.once('close', () => {
-      if (isProduction) {
-        console.log('🗃 Database is connection closed', process.env.CI, MONGO_URI);
-      }
-    });
   }
 };
 


### PR DESCRIPTION
## Background
Stop using console.log in order to reduce total cost of logging within GCP.