### PR TITLE
fix(examples): loosen searching examples to match with more flags

### DIFF
--- a/src/controllers/utils/index.ts
+++ b/src/controllers/utils/index.ts
@@ -22,6 +22,10 @@ const createSimpleRegExp = (keywords: { text: string }[]) => ({
     `${keywords.map((keyword) => `(${createRegExp(keyword.text, true).wordReg.source})`).join('|')}`,
     'i'
   ),
+  exampleReg: new RegExp(
+    `${keywords.map((keyword) => `(${createRegExp(keyword.text, true).exampleReg.source})`).join('|')}`,
+    'i'
+  ),
   definitionsReg: new RegExp(
     `${keywords.map((keyword) => `(${createRegExp(keyword.text, true).definitionsReg.source})`).join('|')}`,
     'i'
@@ -48,7 +52,7 @@ const constructRegexQuery = ({
     ? createSimpleRegExp(keywords)
     : keywords?.length
     ? createSimpleRegExp(keywords)
-    : { wordReg: /^[.{0,}\n{0,}]/, definitionsReg: /^[.{0,}\n{0,}]/ };
+    : { wordReg: /^[.{0,}\n{0,}]/, exampleReg: /^[.{0,}\n{0,}]/, definitionsReg: /^[.{0,}\n{0,}]/ };
 
 /* Packages the res response with sorting */
 export const packageResponse = ({

--- a/src/controllers/utils/queries.ts
+++ b/src/controllers/utils/queries.ts
@@ -106,7 +106,7 @@ const definitionsQuery = ({
 
 /* Regex match query used to later to defined the Content-Range response header */
 export const searchExamplesRegexQuery = ({ regex, flags }: { regex: SearchRegExp; flags: Flags }) => ({
-  $or: [{ igbo: regex.wordReg }, { english: regex?.definitionsReg }],
+  $or: [{ igbo: regex.exampleReg }, { english: regex?.definitionsReg }],
   ...(flags.style ? { style: flags.style } : {}),
 });
 export const searchIgboTextSearch = fullTextSearchQuery;

--- a/src/shared/utils/createRegExp.ts
+++ b/src/shared/utils/createRegExp.ts
@@ -4,6 +4,7 @@ import diacriticCodes from '../constants/diacriticCodes';
 
 export interface SearchRegExp {
   wordReg: RegExp;
+  exampleReg: RegExp;
   definitionsReg: RegExp;
   hardDefinitionsReg?: RegExp;
 }
@@ -67,12 +68,13 @@ const createRegExp = (rawSearchWord: string, hardMatch = false): SearchRegExp =>
       : `${startWordBoundary}(^${front}${regexWordString}${back}$)${endWordBoundary}`,
     'i'
   );
-
+  const exampleReg = new RegExp(`${startWordBoundary}(${regexWordString})${endWordBoundary}`, 'i');
   const definitionsReg = new RegExp(`${startWordBoundary}(${regexWordString})${endWordBoundary}`, 'i');
   const hardDefinitionsReg = new RegExp(`${startWordBoundary}(${hardRegexWordString})${endWordBoundary}`, 'i');
 
   return {
     wordReg,
+    exampleReg,
     definitionsReg,
     hardDefinitionsReg,
   };


### PR DESCRIPTION
## Describe your changes
When searching for example sentences, nearly no request would include any examples in the response.

## Issue ticket number and link
N/A

## Motivation and Context
I was trying to use the examples endpoint to get proverbs, but when I would apply the `keyword` and `style=proverb` params, I would get no response even though we have sentences in the database matching the query.

## How Has This Been Tested?
Locally tested with Insomnia

## Screenshots (if appropriate):
![image](https://github.com/nkowaokwu/igbo_api/assets/16169291/1fb6e1a3-acc1-42fe-8e65-728a7ab81391)

