### PR TITLE
Yarn to npm

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,9 +45,9 @@ Double-check to make sure that you have done the following things:
 
 1. If implementing a feature request, create new unit tests to increase confidence in your changes.
     * **You're code will be unable to get merged without new unit tests**
-2. Check to see if your changes are non-breaking by running `yarn test`
+2. Check to see if your changes are non-breaking by running `npm run test`
 3. And install or build dependencies are removed
-    * You can run `yarn clean` to remove unwanted files.
+    * You can run `npm run clean` to remove unwanted files.
 4. Update the README.md with details of changes to the interface, this includes new environment 
    variables, exposed ports, useful file locations, and container parameters.
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,20 +35,20 @@ jobs:
           node-version: '18'
       - name: Install Project Dependencies
         run: |
-          rm -rf ./node_modules; yarn install
+          rm -rf ./node_modules; npm install
           npm install -g firebase-tools
       - name: Install Cloud Dependencies
         run: |
-          cd functions; rm -rf ./node_modules/; yarn; cd ..; pwd
+          cd functions; rm -rf ./node_modules/; npm install; cd ..; pwd
           firebase use default --token $FIREBASE_TOKEN
       - name: Migrate MongoDB Data
         run: |
           firebase functions:config:set env.redis_status=true runtime.env=production --token $FIREBASE_TOKEN
-          yarn migrate-up
+          npm run migrate-up
       - name: Build Production Project
         run: |
           firebase functions:config:set runtime.env=production --token $FIREBASE_TOKEN
-          yarn build
+          npm run build
       - name: Deploy Production Firebase Functions
         run: |
           firebase deploy --project=igbo-api-bb22d --only functions

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,14 +32,14 @@ jobs:
           mongodb-version: ${{ matrix.mongodb-version }}
       - name: Install Project Dependencies
         run: |
-          rm -rf ./node_modules; yarn install
+          rm -rf ./node_modules; npm install
           npm install -g firebase-tools
       - name: Build Server
         run: |
-          yarn build
+          npm run build
       - name: Test Server Build Process
-        run: yarn test:build
+        run: npm run test:build
       - name: Test Backend
-        run: yarn jest:backend
+        run: npm run jest:backend
       - name: Test Frontend
-        run: yarn jest:frontend
+        run: npm run jest:frontend

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           node-version: 18
 
       - name: Install Node.js dependencies
-        run: yarn install
+        run: npm install
 
       - name: Run ESLint
-        run: yarn run eslint ./src --ext .js,.jsx,.ts,.tsx -c ./.eslintrc.js
+        run: npm run eslint ./src --ext .js,.jsx,.ts,.tsx -c ./.eslintrc.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: 20
       - name: Install Dependencies
-        run: yarn install
+        run: npm install
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_ACCESS_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@ WORKDIR /app
 
 COPY package.json ./
 
-RUN yarn install
+RUN npm install
 
 COPY . .
 
-RUN yarn build
+RUN npm run build
 
 ENV PORT=8080
 ENV CONTAINER_HOST=mongodb
 
 EXPOSE 8080
 
-CMD ["yarn", "start"]
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Let's get the Igbo API running locally on your machine.
 To run this project locally, please install the following:
 
 - [Node.js](https://nodejs.org/en/download/)
-- [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [Mongo for Windows](https://www.mongodb.com/docs/v3.0/tutorial/install-mongodb-on-windows/)
 - [Mongo for Mac](https://www.mongodb.com/docs/v3.0/tutorial/install-mongodb-on-os-x/)
 - [Firebase](https://console.firebase.google.com/)
@@ -50,13 +49,13 @@ Navigate into the project directory and install its dependencies:
 
 ```
 cd igbo_api/
-yarn install
+npm install
 ```
 
 Build the frontend for the site:
 
 ```
-yarn build
+npm run build
 ```
 
 ### 2. Connect Firebase Project
@@ -70,7 +69,7 @@ Please follow the [Firebase Configuration Guide here](./.github/FIREBASE_CONFIG.
 Once you've configured your project, you can start the Igbo API dev server by running:
 
 ```
-yarn dev
+npm run dev
 ```
 
 Navigate to [localhost:8080](http://localhost:8080/) to see the API
@@ -80,7 +79,7 @@ Navigate to [localhost:8080](http://localhost:8080/) to see the API
 To start the dev API server while running [MongoDB Replica sets](https://docs.mongodb.com/manual/replication/) and the [Redis cache](https://redis.io/), run:
 
 ```
-yarn dev:full
+npm run dev:full
 ```
 
 To start a Redis server, run:
@@ -101,7 +100,7 @@ If you don't want to run a local Node and MongoDB, you can use [Docker](https://
 Run the following command:
 
 ```
-yarn start:docker
+npm run start:docker
 ```
 
 Navigate to [localhost:8080](http://localhost:8080) to see the API
@@ -111,7 +110,7 @@ Navigate to [localhost:8080](http://localhost:8080) to see the API
 To start up the front site for the API, run:
 
 ```
-yarn dev:site
+npm run dev:site
 ```
 
 Navigate to [localhost:3000](http://localhost:3000) to see the API front site
@@ -125,7 +124,7 @@ To populate the database complete the following steps:
 The following command places the JSON dictionaries in the `build/` directory:
 
 ```
-yarn build:dictionaries
+npm run build:dictionaries
 ```
 
 Here's an example JSON dictionary file: [ig-en/ig-en_expanded.json](./src/dictionaries/ig-en/ig-en_expanded.json)
@@ -137,7 +136,7 @@ Now that the data has been parsed, it needs to be used to populate, or seed, the
 Start the development server:
 
 ```
-yarn dev
+npm run dev
 ```
 
 Then make a `POST` request to the following route:
@@ -179,7 +178,7 @@ The database has gone through a number of migrations since the beginning of this
 shape as the data in the production MongoDB database, run all MongoDB migration scripts with the following command:
 
 ```
-yarn migrate-up
+npm run migrate-up
 ```
 
 ## Testing
@@ -189,13 +188,13 @@ yarn migrate-up
 Frontend tests focus specifically on the Igbo API homepage using Cypress. First, run:
 
 ```
-yarn build
+npm run build
 ```
 
 To watch frontend tests, run:
 
 ```
-yarn cypress
+npm run cypress
 ```
 
 ### Backend
@@ -203,7 +202,7 @@ yarn cypress
 Backend tests use both locally stored MongoDB and JSON data, so to spin up an instance of MongoDB and start the tests at the same time, run:
 
 ```
-yarn test
+npm run test
 ```
 
 If you want to run your MongoDB instance and tests in separate terminals, you can run:

--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
   "author": "Ijemma Onwuzulike",
   "main": "server.js",
   "scripts": {
-    "build": "rm -rf dist/ && yarn build:site && yarn build:src",
+    "build": "rm -rf dist/ && npm run build:site && npm run build:src",
     "build:functions": "rm -rf functions/src && shx cp -r ./dist ./functions && shx cp -r ./dist/src/dictionaries/ig-en ./functions/dictionaries",
-    "build:src": "tsc && cross-env NODE_ENV=build yarn build:dictionaries && yarn build:functions",
+    "build:src": "tsc && cross-env NODE_ENV=build npm run build:dictionaries && npm run build:functions",
     "build:dictionaries:ig:en": "[ ! -d \"./dist/src/dictionaries\" ] && shx mkdir ./dist/src/dictionaries || echo '' && [ ! -d \"./dist/src/dictionaries/ig-en\" ] && shx mkdir ./dist/src/dictionaries/ig-en || echo 'Igbo to English dictionaries dir already exists'",
     "build:dictionaries:en:ig": "[ ! -d \"./dist/src/dictionaries\" ] && shx mkdir ./dist/src/dictionaries || echo '' && [ ! -d \"./dist/src/dictionaries/en-ig\" ] && shx mkdir ./dist/src/dictionaries/en-ig || echo 'English to Igbo dictionaries dir already exists'",
     "build:dictionaries:nsibidi": "[ ! -d \"./dist/src/dictionaries\" ] && shx mkdir ./dist/src/dictionaries || echo '' && [ ! -d \"./dist/src/dictionaries/nsibidi\" ] && shx mkdir ./dist/src/dictionaries/nsibidi || echo 'Nsibidi dictionary dir already exists'",
-    "prebuild:dictionaries": "yarn build:dictionaries:nsibidi && yarn build:dictionaries:ig:en && yarn build:dictionaries:en:ig && shx cp -r ./src/dictionaries/ig-en ./dist/dictionaries && shx cp -r ./src/dictionaries/en-ig ./dist/dictionaries",
+    "prebuild:dictionaries": "npm run build:dictionaries:nsibidi && npm run build:dictionaries:ig:en && npm run build:dictionaries:en:ig && shx cp -r ./src/dictionaries/ig-en ./dist/dictionaries && shx cp -r ./src/dictionaries/en-ig ./dist/dictionaries",
     "build:dictionaries": "node ./dist/src/dictionaries/buildDictionaries.js",
-    "build:site": "cross-env NEXT_PUBLIC_GA_ID=$GA_TRACKING_ID next build && yarn build:fonts && yarn build:assets",
+    "build:site": "cross-env NEXT_PUBLIC_GA_ID=$GA_TRACKING_ID next build && npm run build:fonts && npm run build:assets",
     "build:fonts": "shx cp -r ./src/public/fonts/ ./dist/fonts",
     "build:assets": "shx cp -r ./src/pages/assets/ ./dist/assets",
     "start:emulators": "node_modules/.bin/firebase emulators:start --only functions,hosting",
-    "start:watch": "nodemon --watch './src' --ext ts,js,tsx,jsx --ignore './functions' --verbose --exec yarn build:src",
+    "start:watch": "nodemon --watch './src' --ext ts,js,tsx,jsx --ignore './functions' --verbose --exec npm run build:src",
     "clean": "shx rm -rf node_modules/ dist/ out/ yarn.lock package-lock.json *.log",
     "kill:project": "fkill :5005 :8085 :8080 :8088 -fs",
     "predev": "firebase functions:config:set runtime.env=development && firebase use staging",
@@ -37,7 +37,7 @@
     "cypress:run": "cypress run",
     "jest:backend": "cross-env NODE_ENV=test jest --forceExit --runInBand --config=jest.backend.config.ts",
     "jest:frontend": "cross-env NODE_ENV=test jest --forceExit --runInBand --config=jest.frontend.config.ts",
-    "jest": "yarn jest:backend && yarn jest:frontend",
+    "jest": "npm run jest:backend && npm run jest:frontend",
     "prestart:database": "[ ! -d \"./db\" ] && shx mkdir ./db || echo 'Database directory exists'",
     "prestart:database:replica": "[ ! -d \"./mongos\" ] && shx mkdir ./mongos || echo 'Parent database directory exists'",
     "prestart:database:primary": "[ ! -d \"./mongos/db1\" ] && shx mkdir ./mongos/db1 || echo 'Primary database directory exists'",
@@ -45,7 +45,7 @@
     "prestart:database:secondary:second": "[ ! -d \"./mongos/db3\" ] && shx mkdir ./mongos/db3 || echo 'Second secondary database directory exists'",
     "start": "node ./dist/src/server.js",
     "start:docker": "docker-compose up",
-    "test:build": "cross-env NODE_ENV=build yarn start",
+    "test:build": "cross-env NODE_ENV=build npm run start",
     "dev:site": "firebase functions:config:set runtime.env=development && next",
     "start:database": "mongod --port 27017 --dbpath ./db --quiet &>/dev/null",
     "start:database:replica": "npm-run-all -p start:database:primary start:database:secondary:first start:database:secondary:second",
@@ -55,8 +55,7 @@
   },
   "engines": {
     "node": ">=18",
-    "npm": "8",
-    "yarn": "1.22.x"
+    "npm": ">=8"
   },
   "husky": {
     "hooks": {
@@ -135,8 +134,7 @@
     "tailwindcss": "3",
     "typescript": "^4.0.3",
     "unicharadata": "^9.0.0-alpha.6",
-    "uuid": "^8.3.2",
-    "yarn": "^1.22.10"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/src/pages/docs/contributing.mdx
+++ b/src/pages/docs/contributing.mdx
@@ -29,9 +29,9 @@ Double check to make sure that you have done the following things:
 
 1. If implementing a feature request, create new unit tests to increase confidence of your changes.
    - **You're code will be unable to get merged without new unit tests**
-2. Check to see if your changes are non-breaking by running `yarn test`
+2. Check to see if your changes are non-breaking by running `npm run test`
 3. And install or build dependencies are removed
-   - You can run `yarn clean` to remove unwanted files.
+   - You can run `npm run clean` to remove unwanted files.
 4. Update the README.md with details of changes to the interface, this includes new environment
    variables, exposed ports, useful file locations and container parameters.
 

--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -9,7 +9,6 @@ If you would like to start using the Igbo API in your production-ready projects,
 You will need the following tools installed on your computer to run the project locally:
 
 - Node.js
-- Yarn
 - MongoDB
 - Firebase
 - Redis (optional)
@@ -27,13 +26,13 @@ Navigate into the project directory and install its dependencies:
 
 ```bash
 cd igbo_api/
-yarn install
+npm install
 ```
 
 Build the frontend for the site:
 
 ```bash
-yarn build
+npm run build
 ```
 
 ## Connect to a Firebase Project
@@ -47,7 +46,7 @@ Please follow the [Firebase Configuration Guide](./guides/firebase).
 Once you've configured your project, you can start the Igbo API dev server by running:
 
 ```bash
-yarn dev
+npm run dev
 ```
 
 **Note:** All requests must be made with `X-API-Key` with the value of `main_key`.
@@ -59,7 +58,7 @@ Navigate to [localhost:8080](http://localhost:8080) to see the API
 If you would like to run the API while running [MongoDB Replica Sets]() and a [Redis cache](), run:
 
 ```bash
-yarn dev:full
+npm run dev:full
 ```
 
 Ensure that you have Redis installed on your machine. Then, run the following to start a Redis server:
@@ -78,7 +77,7 @@ If you don't want to run a local Node and MongoDB service, you can use Docker.
 Run the following command:
 
 ```bash
-yarn start:docker
+npm run start:docker
 ```
 
 Navigate to [localhost:8080](http://localhost:8080) to see the API

--- a/src/pages/docs/guides/migrating.mdx
+++ b/src/pages/docs/guides/migrating.mdx
@@ -9,11 +9,11 @@ following the [`migrate-mongo` guides](https://www.npmjs.com/package/migrate-mon
 Once you've created a migration script, you can run the following command to apply the migration to your local MongoDB database:
 
 ```bash
-yarn migrate-up
+npm run migrate-up
 ```
 
 If you want to rollback your migration, you can run the following command:
 
 ```bash
-yarn migrate-down
+npm run migrate-down
 ```

--- a/src/pages/docs/guides/seeding.mdx
+++ b/src/pages/docs/guides/seeding.mdx
@@ -11,7 +11,7 @@ We will need to build the dictionaries into a file that can be used to populate 
 The following command places the JSON dictionaries in the `dist/` directory:
 
 ```
-yarn build:dictionaries
+npm run build:dictionaries
 ```
 
 Here's an example JSON dictionary file: [ig-en/ig-en_expanded.json](./src/dictionaries/ig-en/ig-en_expanded.json)
@@ -23,7 +23,7 @@ Now that the data has been compiled, it needs to be used to populate, or seed, t
 Start the development server:
 
 ```
-yarn dev
+npm run dev
 ```
 
 Then make a `POST` request to the following route:

--- a/src/pages/docs/guides/testing.mdx
+++ b/src/pages/docs/guides/testing.mdx
@@ -9,13 +9,13 @@ Creating and maintaining our automated tests ensure that the API is always relia
 Frontend tests focus specifically on the Igbo API homepage using Cypress. First, run:
 
 ```
-yarn build
+npm run build
 ```
 
 Then run the following to start Cypress:
 
 ```
-yarn cypress
+npm run cypress
 ```
 
 ## Backend
@@ -24,17 +24,17 @@ If you would like to have one terminal dedicated to running tests (the downside 
 the following:
 
 ```
-yarn test
+npm run test
 ```
 
 If you want to run your MongoDB instance and tests in separate terminals, you can run the following command in one terminal:
 
 ```
-yarn start:database
+npm run start:database
 ```
 
 Open another terminal and run the following:
 
 ```
-yarn jest
+npm run jest
 ```


### PR DESCRIPTION
## Background
We want to start using `npm` instead of `yarn` since `npm` does a better job at checking package dependencies' versions.