### PR TITLE
Fix #779 : Remove the should prefix from all unit tests titles

### DIFF
--- a/__tests__/api-json.test.ts
+++ b/__tests__/api-json.test.ts
@@ -4,7 +4,7 @@ import { searchTerm } from './shared/commands';
 
 describe('JSON Dictionary', () => {
   describe('/GET words', () => {
-    it.skip('should return back word information', async () => {
+    it.skip('return back word information', async () => {
       const keyword = 'agụū';
       const res = await searchTerm(keyword);
       expect(res.status).toEqual(200);
@@ -14,13 +14,13 @@ describe('JSON Dictionary', () => {
       expect(res.body[keyword][0].wordClass).toEqual('NNC');
     });
 
-    it('should return an error for searching no word', async () => {
+    it('return an error for searching no word', async () => {
       const res = await searchTerm();
       expect(res.status).toEqual(400);
       expect(res.body.error).toEqual(NO_PROVIDED_TERM);
     });
 
-    it.skip('should return the same term information', async () => {
+    it.skip('return the same term information', async () => {
       const { status, body: normalizeData } = await searchTerm('ndi ndi');
       expect(status).toEqual(200);
       const { status: rawStatus, body: rawData } = await searchTerm('ndị ndi');
@@ -28,7 +28,7 @@ describe('JSON Dictionary', () => {
       expect(isEqual(normalizeData, rawData)).toEqual(true);
     });
 
-    it('should return term using variation', async () => {
+    it('return term using variation', async () => {
       const res = await searchTerm('-mu-mù');
       expect(res.status).toEqual(200);
       expect(res.body['-mụ-mù']).toHaveLength(1);

--- a/__tests__/api-mongo.test.ts
+++ b/__tests__/api-mongo.test.ts
@@ -25,7 +25,7 @@ const { ObjectId } = mongoose.Types;
 
 describe('MongoDB Words', () => {
   describe('mongodb collection', () => {
-    it('should populate mongodb with words', async () => {
+    it('populate mongodb with words', async () => {
       const connection = createDbConnection();
       const Word = connection.model('Word', wordSchema);
       const word = {
@@ -64,7 +64,7 @@ describe('MongoDB Words', () => {
       expect(v2WordRes.body.data.dialects[0].word).toEqual('dialectalWord');
     });
 
-    it('should fail populate mongodb with incorrect variations', async () => {
+    it('fail populate mongodb with incorrect variations', async () => {
       const connection = createDbConnection();
       const Word = connection.model('Word', wordSchema);
       const word = {
@@ -91,7 +91,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should throw an error for invalid data', async () => {
+    it('throw an error for invalid data', async () => {
       const connection = createDbConnection();
       const Word = connection.model('Word', wordSchema);
       const word = {
@@ -113,7 +113,7 @@ describe('MongoDB Words', () => {
   });
 
   describe('/GET mongodb words V1', () => {
-    it('should return word information', async () => {
+    it('return word information', async () => {
       const keyword = 'bia';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -125,7 +125,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return back word information by searching definition', async () => {
+    it('return back word information by searching definition', async () => {
       const keyword = 'smallpox';
       const words = ['kịtịkpā', 'ùlì', 'ajō ọfịa'];
       const res = await getWords({ keyword }, {});
@@ -133,21 +133,21 @@ describe('MongoDB Words', () => {
       forEach(res.body, (word) => expect(words).toContain(word.word));
     });
 
-    it("should return back 'king' documents", async () => {
+    it("return back 'king' documents", async () => {
       const keyword = 'king';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it("should return back 'kings' (plural) documents", async () => {
+    it("return back 'kings' (plural) documents", async () => {
       const keyword = 'kings';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it('should return back words related to paradoxa (within paraenthesis)', async () => {
+    it('return back words related to paradoxa (within paraenthesis)', async () => {
       const keyword = 'paradoxa';
       const words = ['òkwùma', 'osisi'];
       const res = await getWords({ keyword }, {});
@@ -155,14 +155,14 @@ describe('MongoDB Words', () => {
       forEach(res.body, (word) => expect(words).toContain(word.word));
     });
 
-    it('should return back ada without Adaeze', async () => {
+    it('return back ada without Adaeze', async () => {
       const keyword = 'ada';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it('should return back Adaeze without ada', async () => {
+    it('return back Adaeze without ada', async () => {
       const keyword = 'adaeze';
       const words = ['àda èzè', 'Àdaèzè'];
       const res = await getWords({ keyword }, {});
@@ -170,28 +170,28 @@ describe('MongoDB Words', () => {
       forEach(res.body, (word) => expect(words).toContain(word.word));
     });
 
-    it("should return gbā ọ̄sọ̄ by searching 'run'", async () => {
+    it("return gbā ọ̄sọ̄ by searching 'run'", async () => {
       const keyword = 'run';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it("should return words using stop word ('who') as search keyword", async () => {
+    it("return words using stop word ('who') as search keyword", async () => {
       const keyword = 'who';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it("should return words using stop word ('what') as search keyword", async () => {
+    it("return words using stop word ('what') as search keyword", async () => {
       const keyword = 'what';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it('should return word information with dialects query', async () => {
+    it('return word information with dialects query', async () => {
       const keyword = 'bia';
       const res = await getWords({ keyword, dialects: true }, {});
       expect(res.status).toEqual(200);
@@ -201,7 +201,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return word information without dialects with malformed dialects query', async () => {
+    it('return word information without dialects with malformed dialects query', async () => {
       const keyword = 'bia';
       const res = await getWords({ keyword, dialects: 'fdsafds' }, {});
       expect(res.status).toEqual(200);
@@ -211,7 +211,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return word information with examples query', async () => {
+    it('return word information with examples query', async () => {
       const keyword = 'bia';
       const res = await getWords({ keyword, examples: true }, {});
       expect(res.status).toEqual(200);
@@ -221,7 +221,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return word information without examples with malformed examples query', async () => {
+    it('return word information without examples with malformed examples query', async () => {
       const keyword = 'bia';
       const res = await getWords({ keyword, examples: 'fdsafds' }, {});
       expect(res.status).toEqual(200);
@@ -231,7 +231,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return word information with the filter query', async () => {
+    it('return word information with the filter query', async () => {
       const filter = 'bia';
       const res = await getWords({ filter: { word: filter } }, {});
       expect(res.status).toEqual(200);
@@ -243,7 +243,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return one word', async () => {
+    it('return one word', async () => {
       const res = await getWords({}, { apiKey: MAIN_KEY });
       expect(res.status).toEqual(200);
       const result = await getWord(res.body[0].id, {}, {});
@@ -253,7 +253,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return an error for incorrect word id', async () => {
+    it('return an error for incorrect word id', async () => {
       const res = await getWords({}, {});
       expect(res.status).toEqual(200);
       const result = await getWord(NONEXISTENT_ID, {}, {});
@@ -261,13 +261,13 @@ describe('MongoDB Words', () => {
       expect(result.error).not.toEqual(undefined);
     });
 
-    it("should return an error because document doesn't exist", async () => {
+    it("return an error because document doesn't exist", async () => {
       const res = await getWord(INVALID_ID, {}, {});
       expect(res.status).toEqual(400);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should return at most twenty five words per request with range query', async () => {
+    it('return at most twenty five words per request with range query', async () => {
       const res = await Promise.all([
         getWords({ range: true }, {}),
         getWords({ range: '[10,34]' }, {}),
@@ -276,31 +276,31 @@ describe('MongoDB Words', () => {
       expectUniqSetsOfResponses(res, 25);
     });
 
-    it('should return at most four words per request with range query', async () => {
+    it('return at most four words per request with range query', async () => {
       const res = await getWords({ range: '[5,8]' }, {});
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(4);
     });
 
-    it('should return at most ten words because of a large range', async () => {
+    it('return at most ten words because of a large range', async () => {
       const res = await getWords({ range: '[10,40]' }, {});
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(10);
     });
 
-    it('should return at most ten words because of a tiny range', async () => {
+    it('return at most ten words because of a tiny range', async () => {
       const res = await getWords({ range: '[10,9]' }, {});
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(10);
     });
 
-    it('should return at most ten words because of an invalid range', async () => {
+    it('return at most ten words because of an invalid range', async () => {
       const res = await getWords({ range: 'incorrect' }, {});
       expect(res.status).toEqual(400);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should return at most ten words per request with range query', async () => {
+    it('return at most ten words per request with range query', async () => {
       const res = await Promise.all([
         getWords({ range: true }, {}),
         getWords({ range: '[10,19]' }, {}),
@@ -310,7 +310,7 @@ describe('MongoDB Words', () => {
       expectUniqSetsOfResponses(res);
     });
 
-    it('should return at most ten words per request due to pagination', async () => {
+    it('return at most ten words per request due to pagination', async () => {
       const res = await Promise.all([
         getWords({}, {}),
         getWords({ page: '1' }, {}),
@@ -319,7 +319,7 @@ describe('MongoDB Words', () => {
       expectUniqSetsOfResponses(res);
     });
 
-    it('should return ignore case', async () => {
+    it('return ignore case', async () => {
       const lowerCase = 'tree';
       const upperCase = 'Tree';
       const res = await Promise.all([
@@ -329,42 +329,42 @@ describe('MongoDB Words', () => {
       expect(res[1].body.length).toBeGreaterThanOrEqual(res[0].body.length);
     });
 
-    it('should return only ten words', async () => {
+    it('return only ten words', async () => {
       const keyword = 'woman';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it('should return only ten words with the filter query', async () => {
+    it('return only ten words with the filter query', async () => {
       const filter = 'woman';
       const res = await getWords({ filter: { word: filter } }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(10);
     });
 
-    it('should throw an error due to negative page number', async () => {
+    it('throw an error due to negative page number', async () => {
       const keyword = 'woman';
       const res = await getWords({ keyword, page: -1 }, {});
       expect(res.status).toEqual(400);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should throw an error due to invalid page number', async () => {
+    it('throw an error due to invalid page number', async () => {
       const filter = 'woman';
       const res = await getWords({ filter: { word: filter }, page: 'fake' }, {});
       expect(res.status).toEqual(400);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it.skip("should return nothing because it's an incomplete word", async () => {
+    it.skip("return nothing because it's an incomplete word", async () => {
       const keyword = 'ak';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(1);
     });
 
-    it('should return igbo words when given english with an exact match', async () => {
+    it('return igbo words when given english with an exact match', async () => {
       const keyword = 'animal; meat';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -372,7 +372,7 @@ describe('MongoDB Words', () => {
       expect(res.body[0].word).toEqual('anụ');
     });
 
-    it('should return igbo words when given english with a partial match', async () => {
+    it('return igbo words when given english with a partial match', async () => {
       const keyword = 'animal';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -384,7 +384,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return igbo word by searching variation', async () => {
+    it('return igbo word by searching variation', async () => {
       const keyword = 'mili';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -397,7 +397,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return multiple word objects by searching variation', async () => {
+    it('return multiple word objects by searching variation', async () => {
       const keyword = '-mu-mù';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -406,7 +406,7 @@ describe('MongoDB Words', () => {
       expect(some(res.body, (word) => isEqual(word.variations, ['-mu-mù']))).toEqual(true);
     });
 
-    it('should return unique words when searching for term', async () => {
+    it('return unique words when searching for term', async () => {
       const keyword = 'ànùnù';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -419,7 +419,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should not include _id and __v keys', async () => {
+    it('not include _id and __v keys', async () => {
       const keyword = 'elephant';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -447,7 +447,7 @@ describe('MongoDB Words', () => {
       );
     });
 
-    it.skip('should return a sorted list of igbo terms when using english', async () => {
+    it.skip('return a sorted list of igbo terms when using english', async () => {
       const keyword = 'water';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -469,40 +469,40 @@ describe('MongoDB Words', () => {
       ).toEqual(true);
     });
 
-    it('should return a list of igbo terms when using english by using single quotes', async () => {
+    it('return a list of igbo terms when using english by using single quotes', async () => {
       const keyword = "'water'";
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('should also return a list of igbo terms when using english by using double quotes', async () => {
+    it('also return a list of igbo terms when using english by using double quotes', async () => {
       const keyword = '"water"';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('should not return any words when wrapping an igbo word in quotes', async () => {
+    it('not return any words when wrapping an igbo word in quotes', async () => {
       const keyword = '"nkanka"';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(0);
     });
 
-    it('should return words with no keyword as an application using MAIN_KEY', async () => {
+    it('return words with no keyword as an application using MAIN_KEY', async () => {
       const res = await getWords({}, { apiKey: MAIN_KEY });
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(10);
     });
 
-    it('should return no words with no keyword as a developer', async () => {
+    it('return no words with no keyword as a developer', async () => {
       const res = await getWords({}, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(0);
     });
 
-    it('should return accented word', async () => {
+    it('return accented word', async () => {
       const res = await getWords({}, {});
       expect(res.status).toEqual(200);
       forEach(res.body, (word) => {
@@ -510,7 +510,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return hard matched words with strict query', async () => {
+    it('return hard matched words with strict query', async () => {
       const keyword = 'akwa';
       const res = await getWords({ keyword, strict: true }, {});
       expect(res.status).toEqual(200);
@@ -521,7 +521,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return loosely matched words without strict query', async () => {
+    it('return loosely matched words without strict query', async () => {
       const keyword = 'akwa';
       const res = await getWords({ keyword, strict: false }, {});
       expect(res.status).toEqual(200);
@@ -532,7 +532,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return a word by searching with nested dialect word', async () => {
+    it('return a word by searching with nested dialect word', async () => {
       const keyword = 'akwa-dialect';
       const res = await getWords({ keyword, dialects: true }, {});
       expect(res.status).toEqual(200);
@@ -542,7 +542,7 @@ describe('MongoDB Words', () => {
       });
     });
 
-    it('should return a word that is a common noun', async () => {
+    it('return a word that is a common noun', async () => {
       const connection = createDbConnection();
       const Word = connection.model('Word', wordSchema);
       const word = {
@@ -574,7 +574,7 @@ describe('MongoDB Words', () => {
       expect(noRes.body).toHaveLength(0);
     });
 
-    it('should return all tenses', async () => {
+    it('return all tenses', async () => {
       const keyword = 'bịa';
       const res = await getWords({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -590,14 +590,14 @@ describe('MongoDB Words', () => {
   });
 
   describe('/GET mongodb words V2', () => {
-    it('should return word parts of mgba for noun deconstruction', async () => {
+    it('return word parts of mgba for noun deconstruction', async () => {
       const keyword = 'mgba';
       const res = await getWordsV2({ keyword }, {});
       expect(res.status).toEqual(200);
       const gbaWord = res.body.data.find(({ word }: { word: string }) => word === 'gba');
       expect(gbaWord).toBeTruthy();
     });
-    it('should return word information', async () => {
+    it('return word information', async () => {
       const keyword = 'bia';
       const res = await getWordsV2({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -610,7 +610,7 @@ describe('MongoDB Words', () => {
         expect(WordClass[wordClass]).not.toBe(undefined);
       });
     });
-    it('should return one word', async () => {
+    it('return one word', async () => {
       const res = await getWordsV2({}, { apiKey: MAIN_KEY });
       expect(res.status).toEqual(200);
       const result = await getWordV2(res.body.data[0].id, {}, {});
@@ -621,31 +621,31 @@ describe('MongoDB Words', () => {
       const { wordClass }: { wordClass: WordClassEnum } = result.body.data.definitions[0];
       expect(WordClass[wordClass]).not.toBe(undefined);
     });
-    it("should return words using stop word ('who') as search keyword", async () => {
+    it("return words using stop word ('who') as search keyword", async () => {
       const keyword = 'who';
       const res = await getWordsV2({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.data).toHaveLength(10);
     });
-    it("should return words using stop word ('what') as search keyword", async () => {
+    it("return words using stop word ('what') as search keyword", async () => {
       const keyword = 'what';
       const res = await getWordsV2({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.data).toHaveLength(10);
     });
-    it('should return word with verb conjugation', async () => {
+    it('return word with verb conjugation', async () => {
       const keyword = 'ajora';
       const res = await getWordsV2({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.data.length).toBeGreaterThanOrEqual(2);
     });
-    it('should return word parts of bịara for verb deconstruction', async () => {
+    it('return word parts of bịara for verb deconstruction', async () => {
       const keyword = 'bịara';
       const res = await getWordsV2({ keyword }, {});
       expect(res.status).toEqual(200);
       expect(res.body.data.length).toBeGreaterThanOrEqual(2);
     });
-    it('should noun with broken portions or word', async () => {
+    it('noun with broken portions or word', async () => {
       const keyword = 'ọrụ';
       const res = await getWordsV2({ keyword }, {});
       const ọrụWord = res.body.data.find(({ word }: { word: string }) => word === 'ọrụ');

--- a/__tests__/developers.test.ts
+++ b/__tests__/developers.test.ts
@@ -3,19 +3,19 @@ import { developerData, malformedDeveloperData, wordId, exampleId } from './__mo
 
 describe('Developers', () => {
   describe('/POST mongodb developers', () => {
-    it('should create a new developer', async () => {
+    it('create a new developer', async () => {
       const res = await createDeveloper(developerData);
       expect(res.status).toEqual(200);
       expect(res.body.message).not.toEqual(undefined);
     });
 
-    it('should throw an error while creating a new developer', async () => {
+    it('throw an error while creating a new developer', async () => {
       const res = await createDeveloper(malformedDeveloperData);
       expect(res.status).toEqual(400);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should throw an error by using the same email for new developers', async () => {
+    it('throw an error by using the same email for new developers', async () => {
       const repeatedDeveloper = {
         ...developerData,
         email: 'email@example.com',
@@ -29,7 +29,7 @@ describe('Developers', () => {
   });
 
   describe('Using Developer API Keys', () => {
-    it('should get all words with API key', async () => {
+    it('get all words with API key', async () => {
       const developerRes = await createDeveloper(developerData);
       expect(developerRes.status).toEqual(200);
       await new Promise((resolve) => {
@@ -39,59 +39,59 @@ describe('Developers', () => {
       expect(res.status).toEqual(200);
     });
 
-    it('should search for a word with API key', async () => {
+    it('search for a word with API key', async () => {
       const developerRes = await createDeveloper(developerData);
       expect(developerRes.status).toEqual(200);
       const res = await getWord(wordId, {}, { apiKey: developerRes.body.apiKey });
       expect(res.status).toEqual(404);
     });
 
-    it('should get examples with API key', async () => {
+    it('get examples with API key', async () => {
       const developerRes = await createDeveloper(developerData);
       expect(developerRes.status).toEqual(200);
       const res = await getExamples({}, { apiKey: developerRes.body.apiKey });
       expect(res.status).toEqual(200);
     });
 
-    it('should search for an example with API key', async () => {
+    it('search for an example with API key', async () => {
       const developerRes = await createDeveloper(developerData);
       expect(developerRes.status).toEqual(200);
       const res = await getExample(exampleId, {}, { apiKey: developerRes.body.apiKey });
       expect(res.status).toEqual(404);
     });
 
-    it('should throw an error getting words with invalid API key', async () => {
+    it('throw an error getting words with invalid API key', async () => {
       const res = await getWords({}, { apiKey: 'invalid key' });
       expect(res.status).toEqual(401);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should throw an error getting a word with invalid API key', async () => {
+    it('throw an error getting a word with invalid API key', async () => {
       const res = await getWord(wordId, {}, { apiKey: 'invalid key' });
       expect(res.status).toEqual(401);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should throw an error getting examples with invalid API key', async () => {
+    it('throw an error getting examples with invalid API key', async () => {
       const res = await getExamples({}, { apiKey: 'invalid key' });
       expect(res.status).toEqual(401);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should throw an error getting an example with invalid API key', async () => {
+    it('throw an error getting an example with invalid API key', async () => {
       const res = await getExample(exampleId, {}, { apiKey: 'invalid key' });
       expect(res.status).toEqual(401);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should throw no error getting examples with mismatching origin', async () => {
+    it('throw no error getting examples with mismatching origin', async () => {
       const developerRes = await createDeveloper(developerData);
       expect(developerRes.status).toEqual(200);
       const res = await getExamples({}, { apiKey: developerRes.body.apiKey, origin: 'invalid' });
       expect(res.status).toEqual(200);
     });
 
-    it('should increase the count by maxing usage limit', async () => {
+    it('increase the count by maxing usage limit', async () => {
       const developerRes = await createDeveloper(developerData);
       expect(developerRes.status).toEqual(200);
       const wordsRes = await getWords({ keyword: 'eat' }, {});

--- a/__tests__/examples.test.ts
+++ b/__tests__/examples.test.ts
@@ -12,26 +12,26 @@ import ExampleStyleEnum from '../src/shared/constants/ExampleStyleEnum';
 
 describe('MongoDB Examples', () => {
   describe('/GET mongodb examples V1', () => {
-    it('should return no examples by searching', async () => {
+    it('return no examples by searching', async () => {
       const res = await getExamples({}, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(0);
     });
 
-    it('should return an example by searching', async () => {
+    it('return an example by searching', async () => {
       const res = await getExamples({}, { apiKey: MAIN_KEY });
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(10);
     });
 
-    it('should return an example by searching with style', async () => {
+    it('return an example by searching with style', async () => {
       const res = await getExamples({ style: ExampleStyleEnum.PROVERB }, { apiKey: MAIN_KEY });
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeGreaterThanOrEqual(1);
       expect(res.body[0].style).toEqual(ExampleStyleEnum.PROVERB);
     });
 
-    it('should return one example', async () => {
+    it('return one example', async () => {
       const res = await getExamples({}, { apiKey: MAIN_KEY });
       const result = await getExample(res.body[0].id, {}, {});
       expect(result.status).toEqual(200);
@@ -40,20 +40,20 @@ describe('MongoDB Examples', () => {
       });
     });
 
-    it('should return an error for incorrect example id', async () => {
+    it('return an error for incorrect example id', async () => {
       await getExamples({}, {});
       const result = await getExample(NONEXISTENT_ID, {}, {});
       expect(result.status).toEqual(404);
       expect(result.error).not.toEqual(undefined);
     });
 
-    it("should return an error because document doesn't exist", async () => {
+    it("return an error because document doesn't exist", async () => {
       const res = await getExample(INVALID_ID, {}, {});
       expect(res.status).toEqual(400);
       expect(res.body.error).not.toEqual(undefined);
     });
 
-    it('should return at most ten example per request with range query', async () => {
+    it('return at most ten example per request with range query', async () => {
       const res = await Promise.all([
         getExamples({ range: '[0,9]' }, {}),
         getExamples({ range: [10, 19] }, {}),
@@ -63,7 +63,7 @@ describe('MongoDB Examples', () => {
       expectUniqSetsOfResponses(res);
     });
 
-    it('should return different sets of example suggestions for pagination', async () => {
+    it('return different sets of example suggestions for pagination', async () => {
       const res = await Promise.all([
         getExamples({ page: 0 }, {}),
         getExamples({ page: 1 }, {}),
@@ -72,7 +72,7 @@ describe('MongoDB Examples', () => {
       expectUniqSetsOfResponses(res);
     });
 
-    it('should return prioritize range over page', async () => {
+    it('return prioritize range over page', async () => {
       const res = await Promise.all([
         getExamples({ page: '1' }, { apiKey: MAIN_KEY }),
         getExamples({ page: '1', range: '[100,109]' }, { apiKey: MAIN_KEY }),
@@ -80,19 +80,19 @@ describe('MongoDB Examples', () => {
       expect(isEqual(res[0].body, res[1].body)).toEqual(false);
     });
 
-    it('should return words with no keyword as an application using MAIN_KEY', async () => {
+    it('return words with no keyword as an application using MAIN_KEY', async () => {
       const res = await getExamples({}, { apiKey: MAIN_KEY });
       expect(res.status).toEqual(200);
       expect(res.body.length).toBeLessThanOrEqual(10);
     });
 
-    it('should return no examples with no keyword as a developer', async () => {
+    it('return no examples with no keyword as a developer', async () => {
       const res = await getExamples({}, {});
       expect(res.status).toEqual(200);
       expect(res.body).toHaveLength(0);
     });
 
-    it('should return accented keyword', async () => {
+    it('return accented keyword', async () => {
       const keyword = 'Òbìàgèlì bì n’Àba';
       const res = await getExamples({ keyword }, {});
       expect(res.status).toEqual(200);
@@ -101,7 +101,7 @@ describe('MongoDB Examples', () => {
       });
     });
 
-    it('should return accented example', async () => {
+    it('return accented example', async () => {
       const res = await getExamples({}, {});
       expect(res.status).toEqual(200);
       forEach(res.body, (example) => {
@@ -109,7 +109,7 @@ describe('MongoDB Examples', () => {
       });
     });
 
-    it('should return examples by style', async () => {
+    it('return examples by style', async () => {
       const res = await getExamples({ style: ExampleStyleEnum.PROVERB }, {});
       expect(res.status).toEqual(200);
       forEach(res.body, (example) => {
@@ -119,7 +119,7 @@ describe('MongoDB Examples', () => {
   });
 
   describe('/GET mongodb examples V2', () => {
-    it('should return one example', async () => {
+    it('return one example', async () => {
       const res = await getExamplesV2({}, { apiKey: MAIN_KEY });
       const result = await getExampleV2(res.body.data[0].id, {}, {});
       expect(result.status).toEqual(200);

--- a/__tests__/homepage.test.ts
+++ b/__tests__/homepage.test.ts
@@ -2,7 +2,7 @@ import { getLocalUrlRoute } from './shared/commands';
 import { SITE_TITLE, DOCS_SITE_TITLE } from './shared/constants';
 
 describe.skip('API Homepage', () => {
-  it('should render the built site', async () => {
+  it('render the built site', async () => {
     const res = await getLocalUrlRoute();
     expect(res.status).toEqual(200);
     expect(res.type).toEqual('text/html');
@@ -12,7 +12,7 @@ describe.skip('API Homepage', () => {
     expect(res.text).toContain(SITE_TITLE);
   });
 
-  it('should render the docs site', async () => {
+  it('render the docs site', async () => {
     const res = await getLocalUrlRoute('/docs');
     expect(res.status).toEqual(200);
     expect(res.type).toEqual('text/html');

--- a/__tests__/nsibidi_characters.test.ts
+++ b/__tests__/nsibidi_characters.test.ts
@@ -2,7 +2,7 @@ import { getNsibidiCharactersV2 } from './shared/commands';
 
 describe('MongoDB Nsibidi Characters', () => {
   describe('/GET mongodb nsibidi characters V2', () => {
-    it('should return nsibidi character by searching', async () => {
+    it('return nsibidi character by searching', async () => {
       const res = await getNsibidiCharactersV2({ keyword: '123' }, {});
       expect(res.status).toEqual(200);
     });

--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -10,13 +10,13 @@ if (!fs.existsSync(mocksDir)) {
 
 describe('Parse', () => {
   describe('Dictionaries', () => {
-    it('should create dictionaries', async () => {
+    it('create dictionaries', async () => {
       await import('../src/dictionaries/buildDictionaries').catch((err) => {
         throw err;
       });
     });
 
-    it('should keep same-cell text in the definition property', async () => {
+    it('keep same-cell text in the definition property', async () => {
       const keyword = 'ama';
       const res = await searchTerm(keyword);
       expect(res.status).toEqual(200);
@@ -25,7 +25,7 @@ describe('Parse', () => {
       expect(res.body[keyword][0].examples).toHaveLength(1);
     });
 
-    it('should include the correct A. B. text for ewu chī', async () => {
+    it('include the correct A. B. text for ewu chī', async () => {
       const keyword = 'chi';
       const {
         body: { chi: res },
@@ -34,7 +34,7 @@ describe('Parse', () => {
       expect(termDefinitions.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('should include all words -kwù-', async () => {
+    it('include all words -kwù-', async () => {
       const keyword = '-kwù-';
       const res = await searchTerm(keyword);
       expect(res.status).toEqual(200);
@@ -44,29 +44,29 @@ describe('Parse', () => {
 
   describe('Utils', () => {
     describe('Regex Search', () => {
-      it('should return term information without included dashes', async () => {
+      it('return term information without included dashes', async () => {
         const res = searchMockedTerm('bia');
         keys(res).forEach((key) => {
           expect(key.charAt(0)).toEqual('b');
         });
       });
 
-      it('should return term with apostrophe by using spaces', async () => {
+      it('return term with apostrophe by using spaces', async () => {
         const res = searchMockedTerm('n oge');
         expect(keys(res)[0]).toEqual("n'oge");
       });
 
-      it('should return term with space with non word characters', async () => {
+      it('return term with space with non word characters', async () => {
         const res = searchMockedTerm('n oge');
         expect(keys(res)[0]).toEqual("n'oge");
       });
 
-      it('should return term with apostrophe by using apostrophe', async () => {
+      it('return term with apostrophe by using apostrophe', async () => {
         const res = searchMockedTerm('ànì');
         expect(keys(res)[0]).toEqual('ànì');
       });
 
-      it('should return all matching terms', async () => {
+      it('return all matching terms', async () => {
         const keyword = 'be';
         const res = await searchTerm(keyword);
         expect(res.status).toEqual(200);
@@ -75,7 +75,7 @@ describe('Parse', () => {
     });
 
     describe('Abbreviations', () => {
-      it('should replace all present valid abbreviations', async () => {
+      it('replace all present valid abbreviations', async () => {
         const withAbbreviations = 'n. noun. num. num.eral aux. v. aux.v. infl. suff.';
         const withoutAbbreviations = replaceAbbreviations(withAbbreviations);
         expect(withoutAbbreviations).toEqual(


### PR DESCRIPTION
## Describe your changes
<!--- Thoughtfully think through your changes. Think of your audience, this PR is public! -->
Hello.
As per the requirement, in order to get rid of the filler word **"should"**, I have completely removed it from the test files.
If at all I misunderstood something or implemented anything incorrectly, then I am extremely sorry.
Kindly let me know if there are any changes required from my end.

## Issue ticket number and link
Closed #779. <!--- <insert issue number with # to have GitHub automatically close the issue - https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword> -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To get rid of the filler word **"should"** that has been requested in #779.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
<!--- Replace this section with a screenshot or N/A if there are no screenshots -->
N/A