### PR TITLE
Modified the style=no_style so it is in a code block

### DIFF
--- a/src/pages/docs/endpoints/examples.mdx
+++ b/src/pages/docs/endpoints/examples.mdx
@@ -29,7 +29,7 @@ Get examples from dictionary
 | Name   | Description | Example |
 | :----- | :----- | :----- |
 | **keyword** *required* | Keyword for querying words |  `keyword=ego` |
-| **style** | Style for requested example sentences | `style=no_style|standard|proverb|biblical` |
+| **style** | Style for requested example sentences | `style=no_style` |standard|proverb|biblical` |
 | **page** | Page for results | `page=1` |
 | **range** | Page for result using [x,y] syntax, max range includes 25 documents | `range=[0, 24]` |
 


### PR DESCRIPTION
## Describe your changes
<!--- Thoughtfully think through your changes. Think of your audience, this PR is public! -->
Made the *style=no_style* into a code block form _`style=no_style`_

## Issue ticket number and link
This is to close issue #781 

<!--- ## Motivation and Context-->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


<!--- ## How Has This Been Tested?-->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Something else to note
I also noticed that there were extra table columns in that row: standard, proverb, and biblical. They didn't render probably because they only exist on that row. It's what caused the code block problem in the first place. Maybe there's information that was supposed to be in there that was omitted? I'm creating a new issue based on that.



