### PR TITLE
Migrate `Copora` and `Projects` + Omit `projectId`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Start MongoDB
-        uses: supercharge/mongodbw-github-action@1.3.0
+        uses: supercharge/mongodb-github-action@1.3.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
       - name: Install Project Dependencies

--- a/migrations/20240928023848-add-languages-to-corpus.js
+++ b/migrations/20240928023848-add-languages-to-corpus.js
@@ -1,0 +1,25 @@
+module.exports = {
+  async up(db) {
+    const collections = ['corpus', 'corpussuggestions'];
+    return collections.map((collection) =>
+      db.collection(collection).updateMany(
+        {},
+        {
+          $set: { languages: [] },
+        }
+      )
+    );
+  },
+
+  async down(db) {
+    const collections = ['corpus', 'corpussuggestions'];
+    return collections.map((collection) =>
+      db.collection(collection).updateMany(
+        {},
+        {
+          $unset: { languages: null },
+        }
+      )
+    );
+  },
+};

--- a/migrations/20240928024053-add-types-to-projecs.js
+++ b/migrations/20240928024053-add-types-to-projecs.js
@@ -1,0 +1,25 @@
+module.exports = {
+  async up(db) {
+    const collections = ['projects'];
+    return collections.map((collection) =>
+      db.collection(collection).updateMany(
+        {},
+        {
+          $set: { types: ['TEXT_AUDIO_ANNOTATION'] },
+        }
+      )
+    );
+  },
+
+  async down(db) {
+    const collections = ['projects'];
+    return collections.map((collection) =>
+      db.collection(collection).updateMany(
+        {},
+        {
+          $unset: { types: null },
+        }
+      )
+    );
+  },
+};

--- a/src/controllers/utils/buildDocs.ts
+++ b/src/controllers/utils/buildDocs.ts
@@ -40,19 +40,19 @@ const removeKeysInNestedDoc = <T>(docs: T[], nestedDocsKey: keyof T) => {
 
 const cleanExamples = ({ examples, version }: { examples: IncomingExample[], version: Version }) =>
   examples.map((example) => {
-    const cleanedExample: Omit<IncomingExample, 'source' | 'translations'> & {
-      igbo: string,
-      english: string,
-      pronunciation?: string,
-      pronunciations?: string[],
-    } = omit(
+    const cleanedExample = omit(
       assign({
         ...example,
         igbo: '',
         english: '',
       }),
-      ['source', 'translations']
-    );
+      ['source', 'translations', 'projectId']
+    ) as Omit<IncomingExample, 'source' | 'translations' | 'projectId'> & {
+      igbo: string,
+      english: string,
+      pronunciation?: string,
+      pronunciations?: string[],
+    };
     if (version === Version.VERSION_1) {
       cleanedExample.pronunciation = example.source.pronunciations?.[0]?.audio || '';
     } else {
@@ -141,7 +141,7 @@ export const findWordsWithMatch = async ({
       (word) => {
         const updatedWord = assign(word);
         // @ts-expect-error different versions
-        updatedWord.examples = cleanExamples({ examples: updatedWord.examples, version });
+        updatedWord.examples = cleanExamples({ examples: updatedWord.examples || [], version });
         return updatedWord;
       }
     );

--- a/src/middleware/helpers/__tests__/authorizeDeveloperUsage.test.ts
+++ b/src/middleware/helpers/__tests__/authorizeDeveloperUsage.test.ts
@@ -65,13 +65,13 @@ describe('authorizeDeveloperUsage', () => {
   });
 
   it('throws error unable finding developer usage', async () => {
-    const route = 'speech-to-text';
+    const path = 'speech-to-text';
     const developer = developerFixture({});
     // @ts-expect-error mockReturnValue
     findDeveloperUsage.mockReturnValue(undefined);
 
     // @ts-expect-error developer
-    authorizeDeveloperUsage({ route, developer }).catch((err) => {
+    authorizeDeveloperUsage({ path, developer }).catch((err) => {
       expect(err.message).toEqual('No developer usage found');
     });
   });

--- a/src/middleware/helpers/__tests__/authorizeDeveloperUsage.test.ts
+++ b/src/middleware/helpers/__tests__/authorizeDeveloperUsage.test.ts
@@ -14,7 +14,7 @@ jest.mock('../createDeveloperUsage');
 
 describe('authorizeDeveloperUsage', () => {
   it("authorizes the current developer's usage", async () => {
-    const route = 'speech-to-text';
+    const path = 'speech-to-text';
     const developer = developerFixture({});
     const developerUsage = developerUsageFixture({});
     // @ts-expect-error mockReturnValue
@@ -25,12 +25,12 @@ describe('authorizeDeveloperUsage', () => {
     });
 
     // @ts-expect-error developer
-    const res = await authorizeDeveloperUsage({ route, developer });
+    const res = await authorizeDeveloperUsage({ path, developer });
     expect(res).toEqual(developerUsage);
   });
 
   it("updates the current developer's usage", async () => {
-    const route = 'speech-to-text';
+    const path = 'speech-to-text';
     const developer = developerFixture({});
     const developerUsage = developerUsageFixture({});
     const developerUsageDocument = {
@@ -42,12 +42,12 @@ describe('authorizeDeveloperUsage', () => {
     findDeveloperUsage.mockReturnValue(developerUsageDocument);
 
     // @ts-expect-error developer
-    await authorizeDeveloperUsage({ route, developer });
+    await authorizeDeveloperUsage({ path, developer });
     expect(developerUsageDocument.usage.count).toEqual(1);
   });
 
   it('creates a fallback developer usage if none exist exclusively for Igbo API', async () => {
-    const route = 'igbo_api';
+    const path = 'igbo_api';
     const developer = developerFixture({ id: documentId });
     const developerUsage = developerUsageFixture({});
     const developerUsageDocument = {
@@ -60,7 +60,7 @@ describe('authorizeDeveloperUsage', () => {
     // @ts-expect-error mockReturnValue
     createDeveloperUsage.mockReturnValue(developerUsageDocument);
     // @ts-expect-error developer
-    await authorizeDeveloperUsage({ route, developer });
+    await authorizeDeveloperUsage({ path, developer });
     expect(createDeveloperUsage).toHaveBeenCalled();
   });
 
@@ -77,7 +77,7 @@ describe('authorizeDeveloperUsage', () => {
   });
 
   it('throws error due to exceeding usage limit', async () => {
-    const route = 'speech-to-text';
+    const path = 'speech-to-text';
     const developer = developerFixture({});
     const developerUsage = developerUsageFixture({
       usage: { date: new Date(), count: ApiUsageLimit[ApiType.SPEECH_TO_TEXT] + 1 },
@@ -90,7 +90,7 @@ describe('authorizeDeveloperUsage', () => {
     });
 
     // @ts-expect-error developer
-    authorizeDeveloperUsage({ route, developer }).catch((err) => {
+    authorizeDeveloperUsage({ path, developer }).catch((err) => {
       expect(err.message).toEqual('You have exceeded your limit for this API for the day.');
     });
   });


### PR DESCRIPTION
## Background
We want to add the `languages` field on the `Corpus` and `CorpusSuggestions` models so that we can better understand what text is within each Corpus. Additionally, we want to support multiple types of projects, so a new `types` field will live on the `Projects` model.

Finally, the `projectId` field was leaking into API responses for Example sentences, so this PR omits `projectId` only to include information relevant to the requester.