### PR TITLE
Correct Translation endpoint response key

### DIFF
--- a/src/controllers/translation.ts
+++ b/src/controllers/translation.ts
@@ -17,7 +17,7 @@ const TranslationRequestBody = z
   })
   .strict();
 
-interface Translation {
+export interface Translation {
   translation: string;
 }
 
@@ -73,7 +73,7 @@ export const getTranslation: MiddleWare = async (req, res, next) => {
       data: payload,
     });
 
-    return res.send({ transcription: response.translation });
+    return res.send({ translation: response.translation });
   } catch (err) {
     return next(err);
   }

--- a/src/pages/APIs/PredictionAPI.ts
+++ b/src/pages/APIs/PredictionAPI.ts
@@ -2,13 +2,10 @@ import { useCallable } from '../../pages/hooks/useCallable';
 import DemoOption from '../../shared/constants/DemoOption';
 import LanguageEnum from '../../shared/constants/LanguageEnum';
 import { OutgoingWord } from '../../types';
+import { Translation } from '../../controllers/translation';
 
 export interface Prediction {
   transcription: string;
-}
-
-export interface Translation {
-  translation: string;
 }
 
 export interface Dictionary {

--- a/src/pages/components/UseCases/UseCaseCard.tsx
+++ b/src/pages/components/UseCases/UseCaseCard.tsx
@@ -1,4 +1,4 @@
-import { As, Box, Heading, HStack, Text, VStack } from '@chakra-ui/react';
+import { Box, Heading, HStack, Text, VStack } from '@chakra-ui/react';
 
 const UseCaseCard = ({
   label,
@@ -8,7 +8,7 @@ const UseCaseCard = ({
   flexDirection,
 }: {
   label: string,
-  as: As,
+  as: 'h1' | 'h2' | 'h3',
   description: string,
   image: string,
   flexDirection: 'row' | 'row-reverse',

--- a/src/pages/shared/useCases.ts
+++ b/src/pages/shared/useCases.ts
@@ -1,9 +1,7 @@
-import { As } from '@chakra-ui/react';
-
 const useCases = [
   {
     label: 'Generate Subtitles',
-    as: 'h1' as As,
+    as: 'h1',
     description:
       'Generate Igbo subtitles to reach more native speakers across the world. Perfect for content-producing teams.',
     image:
@@ -11,7 +9,7 @@ const useCases = [
   },
   {
     label: 'Transcribe Conversations',
-    as: 'h1' as As,
+    as: 'h1',
     description:
       'Convert Igbo speech into text, in real-time. Perfect for team capturing customer conversations like telehealth or insurance companies.',
     image:
@@ -19,12 +17,12 @@ const useCases = [
   },
   {
     label: 'Build Language Learning Services',
-    as: 'h1' as As,
+    as: 'h1',
     description:
       'Rely on the +25,000 Igbo words and +100,000 Igbo sentences to build experiences for language learners. Perfect for e-learning teams.',
     image:
       'https://images.pexels.com/photos/27541898/pexels-photo-27541898/free-photo-of-drummers.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
   },
-];
+] as const;
 
 export default useCases;


### PR DESCRIPTION
## Describe your changes
Fix the translation endpoint for the Igbo API.

It is currently returning `transcription: <translation>` instead of `translation: <translation>`. This is likely causing typescript error that bubble up in prod but not locally.

This PR also fixes some other TS errors caused by importing `As` from `@chakra-ui/react`