### PR TITLE
Introduce Paywalls and add ownerFirebaseId on Projects

### DIFF
--- a/migrations/20241203060241-insert-owner-firebase-id-on-project.js
+++ b/migrations/20241203060241-insert-owner-firebase-id-on-project.js
@@ -1,0 +1,51 @@
+const determineOwnerUserProjectPermission = (projectId) => [
+  {
+    $match: {
+      projectId,
+      role: 'admin',
+    },
+  },
+  {
+    $sort: {
+      createdAt: 1,
+    },
+  },
+  {
+    $limit: 1,
+  },
+  {
+    $addFields: {
+      isOwner: true,
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    const projects = await db.collection('projects').find().toArray();
+    await Promise.all(
+      projects.map(async (project) => {
+        const uRawDocs = await db
+          .collection('userprojectpermissions')
+          .aggregate(determineOwnerUserProjectPermission(project._id));
+        const firstUserProjectPermission = (await uRawDocs.toArray())[0];
+        const ownerUserProjectPermission =
+          firstUserProjectPermission && firstUserProjectPermission.isOwner
+            ? firstUserProjectPermission
+            : { firebaseId: undefined };
+
+        db.collection('projects').updateMany(
+          {
+            _id: project._id,
+          },
+          { $set: { ownerFirebaseId: ownerUserProjectPermission.firebaseId } }
+        );
+      })
+    );
+  },
+
+  async down(db) {
+    db.collection('userprojectpermissions').updateMany({}, [{ $unset: 'isOwner' }]);
+    db.collection('projects').updateMany({}, [{ $unset: 'ownerFirebaseId' }]);
+  },
+};

--- a/migrations/20241203060300-connect-paywall-to-project.js
+++ b/migrations/20241203060300-connect-paywall-to-project.js
@@ -1,0 +1,69 @@
+const getAllExamples = (projectId) => [
+  {
+    $match: {
+      projectId,
+    },
+  },
+];
+
+const getAllExampleSuggestions = (projectId) => [
+  {
+    $match: {
+      projectId,
+      merged: null,
+      mergedBy: null,
+    },
+  },
+];
+
+const getAllAudioPronunciations = (projectId) => [
+  {
+    $match: {
+      projectId,
+    },
+  },
+];
+
+module.exports = {
+  async up(db) {
+    db.createCollection('paywalls');
+    const projects = db.collection('projects').find();
+    return await Promise.all(
+      (await projects.toArray()).map(async (project) => {
+        const examples = await db
+          .collection('examples')
+          .aggregate(getAllExamples(project._id))
+          .toArray();
+        const exampleSuggestions = await db
+          .collection('examplesuggestions')
+          .aggregate(getAllExampleSuggestions(project._id))
+          .toArray();
+        const audioPronunciations = await db
+          .collection('audiopronunciations')
+          .aggregate(getAllAudioPronunciations(project._id))
+          .toArray();
+
+        db.collection('paywalls').insertOne({
+          projectId: project._id,
+          totalExampleSuggestions: exampleSuggestions.length,
+          totalExamples: examples.length,
+          totalAudioPronunciations: audioPronunciations.length,
+          totalBytes: audioPronunciations.reduce((totalBytes, audioPronunciation) => {
+            return (
+              totalBytes +
+              (typeof audioPronunciation.size === 'string'
+                ? parseInt(audioPronunciation.size, 10)
+                : audioPronunciation.size)
+            );
+          }, 0),
+          updatedAt: new Date(),
+          createdAt: new Date(),
+        });
+      })
+    );
+  },
+
+  async down(db) {
+    return db.collection('paywalls').drop();
+  },
+};

--- a/src/controllers/__tests__/speechToText.test.ts
+++ b/src/controllers/__tests__/speechToText.test.ts
@@ -1,9 +1,10 @@
 import axios from 'axios';
 import {
+  nextFunctionFixture,
   requestFixture,
   responseFixture,
-  nextFunctionFixture,
 } from '../../__tests__/shared/fixtures';
+import { IGBO_STT_API } from '../../config';
 import { getTranscription } from '../speechToText';
 import { fetchBase64Data } from '../utils/fetchBase64Data';
 
@@ -38,12 +39,12 @@ describe('speechToText', () => {
     // @ts-expect-error non-existing value
     expect(axios.request.mock.calls[1][0]).toMatchObject({
       method: 'POST',
-      url: 'http://localhost:3333/predict',
+      url: IGBO_STT_API,
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': 'main_key',
       },
-      data: { id: 'audioId', url: 'https://igboapi.com' },
+      data: { audioUrl: 'https://igboapi.com' },
     });
   });
 
@@ -71,12 +72,12 @@ describe('speechToText', () => {
     // @ts-expect-error non-existing value
     expect(axios.request.mock.calls[1][0]).toMatchObject({
       method: 'POST',
-      url: 'http://localhost:3333/predict',
+      url: IGBO_STT_API,
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': 'main_key',
       },
-      data: { id: 'audioId', url: 'https://igboapi.com' },
+      data: { audioUrl: 'https://igboapi.com' },
     });
   });
 
@@ -104,12 +105,12 @@ describe('speechToText', () => {
     });
     expect(axios.request).toHaveBeenCalledWith({
       method: 'POST',
-      url: 'http://localhost:3333/predict',
+      url: IGBO_STT_API,
       headers: {
         'Content-Type': 'application/json',
         'X-API-Key': 'main_key',
       },
-      data: { id: 'audioId', url: audioUrl },
+      data: { audioUrl },
     });
   });
 


### PR DESCRIPTION
## Background
We have a new collection called `Paywall` that tracks the limits applied to certain users on [Sabbi](https://dashboard.sabbidata.com). A migration script has been created to create `Paywall` documents for each project currently existing in Sabbi. Additionally, we want to track the owning user on the `Project` collection, so another migration script is created to add `ownerFirebaseId` on the `Project` collection.