### PR TITLE
fix: removes `crowdsourcing` field on `wordsuggesitons` anad `examplesuggestions` collection

### DIFF
--- a/migrations/20241206235108-remove-crowdsourcing.js
+++ b/migrations/20241206235108-remove-crowdsourcing.js
@@ -1,0 +1,17 @@
+module.exports = {
+  async up(db) {
+    const collections = ['wordsuggestions', 'examplesuggestions'];
+    await Promise.all(
+      collections.map(async (collection) => {
+        db.collection(collection).updateMany(
+          {},
+          {
+            $unset: { crowdsourcing: null },
+          }
+        );
+      })
+    );
+  },
+
+  async down() {},
+};


### PR DESCRIPTION
## Background
Introduces a migration script to remove the unused `crowdsourcing` field on `WordSuggestions` and `ExampleSuggestions`.