### PR TITLE
chore: add sabbidata to footer links

### DIFF
--- a/src/pages/components/Footer/Footer.tsx
+++ b/src/pages/components/Footer/Footer.tsx
@@ -23,6 +23,7 @@ import {
   LINKEDIN,
   NKOWAOKWU,
   NKOWAOKWU_CHROME,
+  SABBI_HOME,
   TWITTER,
   YOUTUBE,
 } from '../../../siteConstants';
@@ -52,6 +53,10 @@ const categories = [
       {
         label: 'Chrome Extension',
         href: NKOWAOKWU_CHROME,
+      },
+      {
+        label: 'Sabbi',
+        href: SABBI_HOME,
       },
     ],
   },

--- a/src/pages/components/Footer/__tests__/Footer.test.tsx
+++ b/src/pages/components/Footer/__tests__/Footer.test.tsx
@@ -15,6 +15,7 @@ describe('Footer', () => {
     await findByText('Igbo API');
     await findByText('Nkọwa okwu');
     await findByText('Chrome Extension');
+    await findByText('Sabbi');
 
     await findByText('Resources');
     await findByText('Documentation');

--- a/src/siteConstants.ts
+++ b/src/siteConstants.ts
@@ -24,6 +24,7 @@ export const YOUTUBE = 'https://www.youtube.com/c/IjemmaOnwuzulike';
 export const NKOWAOKWU = 'https://nkowaokwu.com';
 export const NKOWAOKWU_CHROME = 'https://nkowaokwu.com/chrome';
 export const SABBI_DASHBOARD = 'https://dashboard.sabbidata.com';
+export const SABBI_HOME = 'https://sabbidata.com/';
 
 // Resources
 export const HUGGING_FACE = 'https://huggingface.co/nkowaokwu';


### PR DESCRIPTION
## Describe your changes
Added sabbidata to the footer links

## Motivation and Context
We needed to point to Sabbi within the footer on https://igboapi.com/, just below Nkọwa okwu and Chrome Extension

## How Has This Been Tested?
Updated the unit test 'Footer' to accommodate the text added "Sabbi"

## Screenshots
<img width="774" alt="image" src="https://github.com/user-attachments/assets/959e69c8-1294-4d86-94aa-4b34ec7166b1" />

<img width="429" alt="image" src="https://github.com/user-attachments/assets/de64027a-2a79-4844-bf81-bca61e3130dc" />

